### PR TITLE
DAT-16160 DevOps :: Liquibase Parent POM breaks Liquibase Package Manager (LPM)

### DIFF
--- a/cmd/populator/artifactory.go
+++ b/cmd/populator/artifactory.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net/http"
 	"package-manager/internal/app/packages"
-	"strings"
 )
 
 // Artifactory main interface for module artifactory logic
@@ -39,20 +38,11 @@ func GetPomFromURL(url string) gopom.Project {
 // GetCoreVersionFromPom get liquibase core version string from POM object
 func GetCoreVersionFromPom(pom gopom.Project) string {
 	var version string
-	for _, dep := range *pom.Dependencies {
-		if *dep.ArtifactID == "liquibase-core" {
-			if strings.Contains(*dep.Version, "${") {
-				v := strings.TrimPrefix(*dep.Version, "${")
-				v = strings.TrimSuffix(v, "}")
-				for k, prop := range pom.Properties.Entries {
-					if k == v {
-						version = prop
-					}
-				}
-			} else {
-				version = *dep.Version
-			}
+	for k, p := range pom.Properties.Entries {
+		if k == "liquibase.version" {
+			version = p
 		}
 	}
 	return version
 }
+


### PR DESCRIPTION
[DAT-16160](https://datical.atlassian.net/browse/DAT-16160)

refactor(artifactory.go): simplify GetCoreVersionFromPom function logic by directly accessing the "liquibase.version" property from the POM object

How I tested:

1. Deleted the latest versions from several extensions like `liquibase-aws-secrets-manager` and `liquibase-s3-extension``
2. Locally run the same commands as shown in the [nightly-update-packages.yml ](https://github.com/liquibase/liquibase-package-manager/blob/master/.github/workflows/nightly-update-packages.yml)workflow:
```bash
go mod download
make generateExtensionPackages
```
3. Versions are generated with the correct `"liquibaseCore": "4.24.0"` element in `internal/app/packages.json`

