### PR TITLE
bump go version to 1.22

### DIFF
--- a/.github/workflows/nightly-e2e-tests.yml
+++ b/.github/workflows/nightly-e2e-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '^1.21'
+          go-version: '^1.22'
 
       - name: Setup GO environment
         run: |

--- a/.github/workflows/nightly-update-packages.yml
+++ b/.github/workflows/nightly-update-packages.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '^1.21'
+          go-version: '^1.22'
 
       - name: Setup GO environment
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '^1.21'
+          go-version: '^1.22'
 
       - name: Setup GO environment
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module package-manager
 
-go 1.21
+go 1.22
 
 require (
 	github.com/google/go-github/v39 v39.2.0


### PR DESCRIPTION
Bumped go version to fix vulnerability: 
https://scout.docker.com/vulnerabilities/id/CVE-2023-45283 

Based changes on : https://github.com/liquibase/liquibase-package-manager/pull/302 