### PR TITLE
fix codeql, fossa, and sonar

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,71 +1,18 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL"
+name: CodeQL
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ master ]
+    branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ "main" ]
   schedule:
-    - cron: '38 12 * * 3'
+    - cron: '16 14 * * 4'
 
 jobs:
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'go' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+  codeql:
+    uses: liquibase/build-logic/.github/workflows/codeql.yml@v0.6.8
+    secrets: inherit
+    with:
+      languages: '["go"]'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,10 +3,10 @@ name: CodeQL
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [ "master" ]
   schedule:
     - cron: '16 14 * * 4'
 

--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,16 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+   ---------------------------------------------------------------------------
+
+   This project includes software governed by the Mozilla Public License, v. 2.0.
+   If a copy of the MPL was not distributed with this file, You can obtain one at
+   http://mozilla.org/MPL/2.0/.
+
+   The following component is subject to the Mozilla Public License, v. 2.0:
+
+- `github.com/hashicorp/go-version v1.6.0`
+
+   You can obtain a copy of the license at:
+   http://mozilla.org/MPL/2.0/.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+This project makes use of third-party software governed by the following licenses:
+
+- `github.com/hashicorp/go-version v1.6.0` is licensed under the Mozilla Public License, v. 2.0.
+  You can obtain a copy of the license at: <http://mozilla.org/MPL/2.0/>.
+
+  For the complete terms, see the LICENSE file in the `github.com/hashicorp/go-version` repository.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # lpm - Liquibase Package Manager
+
 ![GitHub Release Date](https://img.shields.io/github/release-date/liquibase/liquibase-package-manager?style=flat-square)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/liquibase/liquibase-package-manager?style=flat-square)
 ![GitHub all releases](https://img.shields.io/github/downloads/liquibase/liquibase-package-manager/total?style=flat-square)
@@ -8,25 +9,32 @@
 Easily manage external dependencies for Database Development. Search for, install, and uninstall liquibase drivers, extensions, and utilities.
 
 ## lpm is experimental and not officially supported
-lpm is an experimental project. Issues can be reported [here](https://github.com/liquibase/liquibase-package-manager/issues), but there is no guarantee of support. 
+
+lpm is an experimental project. Issues can be reported [here](https://github.com/liquibase/liquibase-package-manager/issues), but there is no guarantee of support.
 
 ## Installation
+
 lpm is distributed as a single binary. Install lpm by downloading, unzipping, and moving it to a directory included in your system's PATH. Releases are available [here](https://github.com/liquibase/liquibase-package-manager/releases).
 
 ## Setup
+
 lpm will make a best effort to locate the location of the liquibase lib directory. It is recommended to set the LIQUIBASE_HOME environment variable.
 
 Examples:
+
 ```shell
 export LIQUIBASE_HOME=/usr/local/opt/liquibase/libexec
 echo  'export LIQUIBASE_HOME=/usr/local/opt/liquibase/libexec' >> ~/.bashrc 
 ```
 
 ## Usage
+
 ```shell
 lpm <command>
 ```
+
 ### Available Commands
+
 * add
 * completion
 * dedupe
@@ -39,24 +47,30 @@ lpm <command>
 * upgrade
 
 ## Autocompletion
+
 lpm can generate shell completions for multiple shells. The following shells are available:
 
 ### bash
+
 Generate the autocompletion script for lpm for the bash shell.
 To load completions in your current shell session:
 `source <(lpm completion bash)`
 
 To load completions for every new session, execute once:
-- Linux:
+* Linux:
+
 ```shell
 lpm completion bash > /etc/bash_completion.d/lpm
 ```
+
 - MacOS:
+
 ```shell
 lpm completion bash > /usr/local/etc/bash_completion.d/lpm
 ```
 
 ### zsh
+
 To load completions in your current shell session:
 `source <(lpm completion zsh)`
 
@@ -64,6 +78,7 @@ To load completions for every new session, execute once:
 `lpm completion zsh > "${fpath[1]}/_lpm"`
 
 ### fish
+
 To load completions in your current shell session:
 `lpm completion fish | source`
 
@@ -71,3 +86,11 @@ To load completions for every new session, execute once:
 `lpm completion fish > ~/.config/fish/completions/lpm.fish`
 
 You will need to start a new shell for this setup to take effect.
+
+## License
+
+This project is licensed under the Apache License 2.0. See the LICENSE file for details.
+
+This project also includes software governed by the Mozilla Public License, v. 2.0.
+
+* `github.com/hashicorp/go-version v1.6.0` (<http://mozilla.org/MPL/2.0/>)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module package-manager
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/google/go-github/v39 v39.2.0


### PR DESCRIPTION
- use reusable workflow codeql
- explicitly define go version 1.22.0 as required