### PR TITLE
bump go version for cve-2024-24790

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module package-manager
 
-go 1.22.0
+go 1.22.4
 
 require (
 	github.com/google/go-github/v39 v39.2.0


### PR DESCRIPTION
This PR address: https://github.com/liquibase/liquibase-package-manager/security/advisories/GHSA-gwm4-prqx-vgq6 