### PR TITLE
fix-CVE-2024-24791

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module package-manager
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/google/go-github/v39 v39.2.0


### PR DESCRIPTION
Detected here: https://github.com/liquibase/docker/actions/runs/9888591243

⬆️ (go.mod): upgrade Go version from 1.22.4 to 1.22.5 to stay up-to-date with the latest version and take advantage of any new features or improvements.