### PR TITLE
Update nightly-update-packages.yml

### DIFF
--- a/.github/workflows/nightly-update-packages.yml
+++ b/.github/workflows/nightly-update-packages.yml
@@ -40,7 +40,7 @@ jobs:
           signoff: false
           branch: update/packages
           delete-branch: true
-          base: master
+          base: ${{ github.ref_name }} 
           title: '[Automatic] Update packages.json'
           body: |
             Automatic update to packages.json

--- a/.github/workflows/nightly-update-packages.yml
+++ b/.github/workflows/nightly-update-packages.yml
@@ -40,6 +40,7 @@ jobs:
           signoff: false
           branch: update/packages
           delete-branch: true
+          base: master
           title: '[Automatic] Update packages.json'
           body: |
             Automatic update to packages.json


### PR DESCRIPTION
fix: `.github/workflows/nightly-update-packages.yml`:
resolve issue : `Error: When the repository is checked out on a commit instead of a branch, the 'base' input must be supplied.`
<img width="1335" alt="Screenshot 2024-07-31 at 1 39 11 PM" src="https://github.com/user-attachments/assets/d42a32e6-bb9b-4687-b113-b6ce17fb0f9c">
