### PR TITLE
Update packages.json

### DIFF
--- a/internal/app/packages.json
+++ b/internal/app/packages.json
@@ -14,7 +14,7 @@
         "tag": "v1.0.1",
         "path": "https://github.com/liquibase/liquibase-aws-license-service/releases/download/v1.0.1/liquibase-aws-license-service-1.0.1.jar",
         "algorithm": "SHA1",
-        "checksum": "87a55c1c7a512379e02736857202ceed6f5c977e",
+        "checksum": "bc8dc8271d64e54c008b6655b082a22198734652",
         "liquibaseCore": "4.29.2"
       }
     ]


### PR DESCRIPTION
fix: `internal/app/packages.json`: sha in liquibase-aws-license-service is different :https://github.com/liquibase/liquibase-aws-license-service/releases. Check the sha from asset : liquibase-aws-license-service-1.0.1.jar.sha1