### PR TITLE
DAT-18926: use @main from build logic

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   codeql:
-    uses: liquibase/build-logic/.github/workflows/codeql.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/codeql.yml@main
     secrets: inherit
     with:
       languages: '["go"]'


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/codeql.yml` file to update the version of the `codeql` workflow being used.

* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L15-R15): Updated the `uses` directive to reference the `main` branch instead of a specific version (`v0.7.8`).