### PR TITLE
Bump go lang from 1.22.7 to 1.22.11 to remediate cve's

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module package-manager
 
-go 1.22.7
+go 1.22.11
 
 require (
 	github.com/google/go-github/v39 v39.2.0


### PR DESCRIPTION
Bump go to remediate cve's

"go1.22.8 (released 2024-10-01) includes fixes to cgo, and the maps and syscall packages. See the [Go 1.22.8 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.22.8+label%3ACherryPickApproved) on our issue tracker for details.

go1.22.9 (released 2024-11-06) includes fixes to the linker. See the [Go 1.22.9 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.22.9+label%3ACherryPickApproved) on our issue tracker for details.

go1.22.10 (released 2024-12-03) includes fixes to the runtime and the syscall package. See the [Go 1.22.10 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.22.10+label%3ACherryPickApproved) on our issue tracker for details.

go1.22.11 (released 2025-01-16) includes security fixes to the crypto/x509 and net/http packages, as well as bug fixes to the runtime. See the [Go 1.22.11 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.22.11+label%3ACherryPickApproved) on our issue tracker for details."

Source:
https://go.dev/doc/devel/release#go1.22.0