### PR TITLE
Update modules.go

### DIFF
--- a/cmd/populator/modules.go
+++ b/cmd/populator/modules.go
@@ -21,7 +21,7 @@ func init() {
     modules = []Module{
 		{
 			name:        "liquibase-aws-extension",
-			category:    Extension,
+			category:    Pro,
 			owner:       "liquibase",
 			repo:        "liquibase-aws-extension",
 			artifactory: Maven{},


### PR DESCRIPTION
This pull request includes a change to the `cmd/populator/modules.go` file, specifically within the `func init() {` function. The change reclassifies the `liquibase-aws-extension` module from the `Extension` category to the `Pro` category.

* [`cmd/populator/modules.go`](diffhunk://#diff-bc75c8b789e17a309b4032fc67030b7e6a6b9f7c260f41d05fd2619c6becf905L24-R24): Changed the category of the `liquibase-aws-extension` module from `Extension` to `Pro`.Change Category to Pro for AWS Extension