### PR TITLE
🔧 fetch artifact from Maven central

### DIFF
--- a/cmd/populator/modules.go
+++ b/cmd/populator/modules.go
@@ -21,9 +21,8 @@ func init() {
     modules = []Module{
 		{
 			name:        "liquibase-aws-extension",
-			category:    Extension,
-			owner:       "liquibase",
-			repo:        "liquibase-aws-extension",
+			category:    Pro,
+			url:         "https://repo1.maven.org/maven2/org/liquibase/ext/liquibase-aws-extension",
 			artifactory: Maven{},
 		},
         {
@@ -34,7 +33,7 @@ func init() {
         },
         {
             name:        "liquibase-aws-license-service",
-            category:    Extension,
+            category:    Pro,
             owner:       "liquibase",
             repo:        "liquibase-aws-license-service",
             artifactory: Github{},

--- a/internal/app/packages.json
+++ b/internal/app/packages.json
@@ -1,11 +1,11 @@
 [
   {
     "name": "liquibase-aws-extension",
-    "category": "extension",
+    "category": "pro",
     "versions": [
       {
         "tag": "v1.0.0",
-        "path": "https://github.com/liquibase/liquibase-aws-extension/releases/download/v1.0.0/liquibase-aws-extension-1.0.0.jar",
+        "path": "https://repo1.maven.org/maven2/org/liquibase/io/ext/liquibase-aws-extension/1.0.0/liquibase-aws-extension-1.0.0.jar",
         "algorithm": "SHA1",
         "checksum": "4d66f84d14eb7240204f12c32ea6dcf462ba9cdf",
         "liquibaseCore": "4.31.1"


### PR DESCRIPTION
1. This pull request includes changes to update the categorization and URLs of certain modules and packages. The most important changes include modifying the category of `liquibase-aws-extension` and `liquibase-aws-license-service` from "Extension" to "Pro" and updating the URLs to point to the Maven repository.
2. Original PR comments : https://github.com/liquibase/liquibase-package-manager/pull/488
3. Changes to module categorization and URLs:

* [`cmd/populator/modules.go`](diffhunk://#diff-bc75c8b789e17a309b4032fc67030b7e6a6b9f7c260f41d05fd2619c6becf905L24-R25): Changed the category of `liquibase-aws-extension` and `liquibase-aws-license-service` from "Extension" to "Pro". Updated the URL for `liquibase-aws-extension` to point to the Maven repository. [[1]](diffhunk://#diff-bc75c8b789e17a309b4032fc67030b7e6a6b9f7c260f41d05fd2619c6becf905L24-R25) [[2]](diffhunk://#diff-bc75c8b789e17a309b4032fc67030b7e6a6b9f7c260f41d05fd2619c6becf905L37-R36)
* [`internal/app/packages.json`](diffhunk://#diff-0b0a9d274bd84c7dbfff4680de10599cd0d96458b06b74a925b2bcd3e3fc2fadL4-R8): Updated the category of `liquibase-aws-extension` from "extension" to "pro" and changed the path URL to point to the Maven repository.