### PR TITLE
version: LoadLiquibase: handle errors properly

### DIFF
--- a/internal/app/commands/add.go
+++ b/internal/app/commands/add.go
@@ -2,13 +2,14 @@ package commands
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-version"
-	"github.com/spf13/cobra"
 	"package-manager/internal/app"
 	"package-manager/internal/app/dependencies"
 	"package-manager/internal/app/errors"
 	"package-manager/internal/app/packages"
 	"strings"
+
+	"github.com/hashicorp/go-version"
+	"github.com/spf13/cobra"
 )
 
 // addCmd represents the add command
@@ -36,7 +37,10 @@ var addCmd = &cobra.Command{
 					errors.Exit("Version '"+strings.Split(name, "@")[1]+"' not available.", 1)
 				}
 				if p.Category != "driver" {
-					core, _ := version.NewVersion(v.LiquibaseCore)
+					core, err := version.NewVersion(v.LiquibaseCore)
+					if err != nil {
+						errors.Exit("Invalid version of "+name+".", 1)
+					}
 					if liquibase.Version.LessThan(core) {
 						errors.Exit(name+" is not compatible with liquibase v"+liquibase.Version.String()+". Please consider updating liquibase.", 1)
 					}
@@ -52,9 +56,9 @@ var addCmd = &cobra.Command{
 				}
 			}
 			if p.InClassPath(app.ClasspathFiles) {
-                v := p.GetInstalledVersion(app.ClasspathFiles)
-                fmt.Println(p.Name + "@" + v.Tag + " is already installed.")
-                fmt.Println(name + " can not be installed.")
+				v := p.GetInstalledVersion(app.ClasspathFiles)
+				fmt.Println(p.Name + "@" + v.Tag + " is already installed.")
+				fmt.Println(name + " can not be installed.")
 				errors.Exit("Consider running `lpm upgrade`.", 1)
 			}
 			if !v.PathIsHTTP() {

--- a/internal/app/utils/Liquibase.go
+++ b/internal/app/utils/Liquibase.go
@@ -3,21 +3,22 @@ package utils
 import (
 	"archive/zip"
 	"bufio"
-	"github.com/hashicorp/go-version"
 	"io"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/hashicorp/go-version"
 )
 
-//Liquibase struct
+// Liquibase struct
 type Liquibase struct {
 	Homepath        string
 	Version         *version.Version
 	BuildProperties map[string]string
 }
 
-//LoadLiquibase loads liquibase struct from home path
+// LoadLiquibase loads liquibase struct from home path
 func LoadLiquibase(hp string) Liquibase {
 	l := Liquibase{
 		Homepath:        hp,
@@ -49,6 +50,9 @@ func LoadLiquibase(hp string) Liquibase {
 
 			for {
 				line, err := reader.ReadString('\n')
+				if err != nil && err != io.EOF {
+					log.Fatalf("Read line: %v", err)
+				}
 
 				// check if the line has = sign
 				// and process the line. Ignore the rest.
@@ -66,7 +70,13 @@ func LoadLiquibase(hp string) Liquibase {
 					break
 				}
 			}
-			v, _ := version.NewVersion(l.BuildProperties["build.version"])
+			v, err := version.NewVersion(l.BuildProperties["build.version"])
+			if err != nil {
+				log.Fatalf("Parsing build.version from properties: %v", err)
+			}
+			if v == nil {
+				log.Fatal("Could not find liquibase version in key 'build.version'")
+			}
 			l.Version = v
 		}
 	}


### PR DESCRIPTION
Fixes a panic while `add`ing a package that has a `build.version` set to non-semantic version:

```
LIQUIBASE_HOME=liquibase ./darwin add liquibase-postgresql@4.5.0
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x1050b2704]
```

With this change, we will get:

```
2025/03/04 22:55:14 Parsing build.version from properties: Malformed version: DEV
```