### PR TITLE
FIX CVE-2025-22871

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module package-manager
 
-go 1.22.11
+go 1.23.8
 
 require (
 	github.com/google/go-github/v39 v39.2.0


### PR DESCRIPTION
Not really affecting `lpm` but it will pop up in customer analysis.

[CVE-2025-22871](https://scout.docker.com/vulnerabilities/id/CVE-2025-22871/org/jandroavicloud?s=golang&n=stdlib&t=golang&vr=%3C1.23.8)

This pull request updates the Go version used in the `package-manager` module to align with the latest stable release.

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the required Go version from `1.22.11` to `1.23.8`, ensuring compatibility with the latest features and improvements.