### PR TITLE
Update go lang for cve remediation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module package-manager
 
-go 1.23.8
+go 1.23.10
 
 require (
 	github.com/google/go-github/v39 v39.2.0


### PR DESCRIPTION
go1.23.8 (released 2025-04-01) includes security fixes to the net/http package, as well as bug fixes to the runtime and the go command. See the [Go 1.23.8 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.8+label%3ACherryPickApproved) on our issue tracker for details.

go1.23.9 (released 2025-05-06) includes fixes to the runtime and the linker. See the [Go 1.23.9 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.9+label%3ACherryPickApproved) on our issue tracker for details.

go1.23.10 (released 2025-06-05) includes security fixes to the net/http and os packages, as well as bug fixes to the linker. See the [Go 1.23.10 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.10+label%3ACherryPickApproved) on our issue tracker for details.