### PR TITLE
Fix GitHub Actions workflow base branch parameter

### DIFF
--- a/.github/workflows/nightly-update-packages.yml
+++ b/.github/workflows/nightly-update-packages.yml
@@ -49,6 +49,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           signoff: false
+          base: master
           branch: update/packages
           delete-branch: true
           title: "[Automatic] Update packages.json"


### PR DESCRIPTION
## Summary
Fixes the failing `nightly-update-packages` workflow by adding the missing `base: master` parameter to the `peter-evans/create-pull-request` action.

## Problem
The workflow was failing when triggered by pull request events with this error:
> When the repository is checked out on a commit instead of a branch, the 'base' input must be supplied.

This happened because:
- Schedule triggers run on the `master` branch ✅ 
- Pull request triggers run on detached HEAD (commit SHA) ❌

## Solution
Added explicit `base: master` parameter to tell the action which branch to target when creating PRs from a detached HEAD state.

## Changes
- Added one line: `base: master` to `.github/workflows/nightly-update-packages.yml`

Fixes the workflow failure in PR #508.