### PR TITLE
DAT-22658: Pin all GitHub Actions to canonical commit SHAs

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Determine version
         id: determine-version
@@ -123,10 +123,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=1.25.7"
           cache: true
@@ -167,7 +167,7 @@ jobs:
           echo "SHA256 for ${{ matrix.arch.zip_name }}: $SHA256"
 
       - name: Upload artifact to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: v${{ env.VERSION }}
@@ -179,7 +179,7 @@ jobs:
           echo "${{ steps.checksum.outputs.sha256 }}  lpm-${VERSION}-${{ matrix.arch.zip_name }}.zip" > checksums/${{ matrix.arch.zip_name }}.txt
 
       - name: Upload checksum artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: checksum-${{ matrix.arch.zip_name }}
           path: checksums/${{ matrix.arch.zip_name }}.txt
@@ -200,7 +200,7 @@ jobs:
 
     steps:
       - name: Download all checksum artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: checksum-*
           path: checksums
@@ -214,7 +214,7 @@ jobs:
           cat checksums.txt
 
       - name: Upload checksums file to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: v${{ env.VERSION }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Create Release Draft
         id: create-release
-        uses: release-drafter/release-drafter@v7
+        uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -16,19 +16,19 @@ jobs:
     env:
       GOOS: linux  # Avoid platform-specific file conflicts (darwin.go/windows.go)
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=1.25.7"
 
       - name: Run govulncheck
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
           repo-checkout: false
 
       - name: Generate SARIF report
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         if: always()
         with:
           repo-checkout: false
@@ -36,7 +36,7 @@ jobs:
           output-file: govulncheck.sarif
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         if: always()
         with:
           sarif_file: govulncheck.sarif

--- a/.github/workflows/nightly-e2e-tests.yml
+++ b/.github/workflows/nightly-e2e-tests.yml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         liquibase: [4.6.0, 4.16.1]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '>=1.25.7'
 

--- a/.github/workflows/nightly-update-packages.yml
+++ b/.github/workflows/nightly-update-packages.yml
@@ -20,9 +20,9 @@ jobs:
   update-packages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=1.25.7"
 
@@ -42,7 +42,7 @@ jobs:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Automatic update to packages.json

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,14 +16,14 @@ jobs:
     steps:
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
         with:
           secret-ids: |
             ,/vault/liquibase
@@ -31,7 +31,7 @@ jobs:
 
       - name: Get GitHub App token
         id: get-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
@@ -39,7 +39,7 @@ jobs:
           permission-contents: write
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
           fetch-depth: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 #Shallow Clones should be disabled for a better relevancy of analysis
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=1.25.7"
 
@@ -34,21 +34,21 @@ jobs:
           go tool cover -func coverage.out
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
         with:
           secret-ids: |
             ,/vault/liquibase
           parse-json-secrets: true
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}

--- a/.github/workflows/update-docker-repo.yml
+++ b/.github/workflows/update-docker-repo.yml
@@ -32,14 +32,14 @@ jobs:
 
     steps:
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
         with:
           secret-ids: |
             ,/vault/liquibase
@@ -47,7 +47,7 @@ jobs:
 
       - name: Get GitHub App token
         id: get-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
@@ -145,7 +145,7 @@ jobs:
           echo "✅ SHA256 checksums validated"
 
       - name: Checkout docker repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: liquibase/docker
           ref: main
@@ -208,7 +208,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check-changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ steps.get-token.outputs.token }}
           commit-message: "Update LPM to version ${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary

- Pins all `uses:` references in 8 workflow files from mutable version tags (`@v6`, `@v2`, `@master`) to immutable commit SHAs, aligning with the [Liquibase org canonical SHA list](https://github.com/liquibase/liquibase-package-manager/blob/master/.github/workflows/) from DAT-21269
- Upgrades `aws-actions/aws-secretsmanager-get-secrets` from v2 → v3.0.0 per the updated canonical list
- Pins `SonarSource/sonarcloud-github-action` from `@master` (branch tracking) to `@ffc30106...` (v5.0.0)

## Actions Pinned

| Action | Version |
|--------|---------|
| `actions/checkout` | v6.0.2 |
| `actions/setup-go` | v6.4.0 |
| `actions/upload-artifact` | v7.0.0 |
| `actions/download-artifact` | v8.0.1 |
| `actions/create-github-app-token` | v3.0.0 |
| `aws-actions/configure-aws-credentials` | v6.0.0 |
| `aws-actions/aws-secretsmanager-get-secrets` | v3.0.0 ⬆️ |
| `github/codeql-action/upload-sarif` | v4.35.1 |
| `release-drafter/release-drafter` | v7.1.1 |
| `softprops/action-gh-release` | v2.6.1 |
| `peter-evans/create-pull-request` | v8.1.0 |
| `golang/govulncheck-action` | v1.0.4 |
| `SonarSource/sonarcloud-github-action` | v5.0.0 |

## Test plan

- [ ] Verify `git diff` shows only `uses:` line changes (no logic changes)
- [ ] Confirm all SHAs match the canonical list in `github-actions-canonical-shas.md`
- [ ] Allow CI to run and confirm workflows execute successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)