### PR TITLE
DAT-22095: Rename default branch references from master to main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,10 +3,10 @@ name: CodeQL
 on:
   workflow_dispatch:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ "main" ]
   schedule:
     - cron: '16 14 * * 4'
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   create-release:

--- a/.github/workflows/nightly-update-packages.yml
+++ b/.github/workflows/nightly-update-packages.yml
@@ -49,7 +49,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           signoff: false
-          base: master
+          base: main
           branch: update/packages
           delete-branch: true
           title: "[Automatic] Update packages.json"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: master
+          ref: main
           fetch-depth: 0
           token: ${{ steps.get-token.outputs.token }}
 
@@ -85,7 +85,7 @@ jobs:
           
           git add VERSION
           git commit -m "Sync VERSION to $NEW_VERSION after release [skip ci]"
-          git push origin master
+          git push origin main
           
           echo "✅ VERSION file synced to $NEW_VERSION"
 
@@ -97,7 +97,7 @@ jobs:
           
           git add internal/app/VERSION
           git commit -m "Update internal VERSION to $NEW_VERSION [skip ci]" || echo "No changes to internal/app/VERSION"
-          git push origin master || echo "Nothing to push"
+          git push origin main || echo "Nothing to push"
 
       - name: Summary
         run: |
@@ -109,7 +109,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           
           if [ "${{ steps.update-version.outputs.updated }}" = "true" ]; then
-            echo "✅ VERSION file updated and committed to master" >> $GITHUB_STEP_SUMMARY
+            echo "✅ VERSION file updated and committed to main" >> $GITHUB_STEP_SUMMARY
           else
             echo "✅ VERSION file already in sync" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: PR Quality Gate
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@
 1. Enable public access for your fork
 1. Make your code changes
 1. Commit your changes (`git commit -am 'Add some feature/folder'`)
-1. Push your changes (`git push origin master`)
-1. Create a Pull Request to [master](https://github.com/liquibase/liquibase-package-manager) branch.
+1. Push your changes (`git push origin main`)
+1. Create a Pull Request to [main](https://github.com/liquibase/liquibase-package-manager) branch.
 
 ## Important Guidelines!
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ LPM uses an **automated release process** with minimal manual intervention.
 
 To create a release:
 
-    Merge PRs to master (labeled appropriately: feature, bug, breaking, etc.)
+    Merge PRs to main (labeled appropriately: feature, bug, breaking, etc.)
     Review the auto-generated draft release on GitHub
     Click Publish release
     Wait ~5-10 minutes for artifacts to build and attach automatically
@@ -194,4 +194,4 @@ For complete release process documentation, troubleshooting, and best practices,
 
 ## Adding an Extension
 
-https://github.com/liquibase/liquibase-package-manager/blob/master/CONTRIBUTING.md
+https://github.com/liquibase/liquibase-package-manager/blob/main/CONTRIBUTING.md

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ This document describes the **fully automated release process** for LPM using Re
 
 **To create a release:**
 
-1. Merge PRs to `master` (labeled appropriately: `feature`, `bug`, `breaking`, etc.)
+1. Merge PRs to `main` (labeled appropriately: `feature`, `bug`, `breaking`, etc.)
 2. Review the auto-generated draft release on GitHub
 3. Click **Publish release**
 4. Wait ~5-10 minutes for artifacts to build and attach automatically
@@ -48,7 +48,7 @@ Before the automated release process can work, the following must be configured:
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  1. Merge PRs to master                                         │
+│  1. Merge PRs to main                                           │
 │     • Ensure PRs are labeled (feature, bug, breaking, etc.)     │
 │     • Labels determine version bump (major/minor/patch)         │
 └────────────────┬────────────────────────────────────────────────┘
@@ -83,7 +83,7 @@ Before the automated release process can work, the following must be configured:
 │     │ B. Sync VERSION File (~10 sec) - PARALLEL            │   │
 │     │    • Updates VERSION file to match release            │   │
 │     │    • Updates internal/app/VERSION                     │   │
-│     │    • Commits to master                                │   │
+│     │    • Commits to main                                  │   │
 │     └───────────────────────────────────────────────────────┘   │
 │                        │                                         │
 │                        ▼ (waits for A to complete)               │
@@ -101,7 +101,7 @@ Before the automated release process can work, the following must be configured:
 
 ## Detailed Step-by-Step Guide
 
-### Step 1: Merge PRs to Master
+### Step 1: Merge PRs to Main
 
 **How versioning works:**
 
@@ -117,7 +117,7 @@ The version is automatically determined by PR labels:
 **Before merging your PR:**
 1. Add appropriate labels to your PR
 2. Verify the PR title and description are clear
-3. Merge to `master`
+3. Merge to `main`
 
 **Pro tip:** You can merge multiple PRs before releasing. Release Drafter will accumulate all changes in the draft release.
 
@@ -127,7 +127,7 @@ The version is automatically determined by PR labels:
 
 **What happens automatically:**
 
-When you push to `master`:
+When you push to `main`:
 
 1. The **Create Release** workflow runs automatically
 2. Release Drafter creates/updates a draft release with:
@@ -137,7 +137,7 @@ When you push to `master`:
 
 **Important**: The draft release contains **ONLY the changelog** at this point. Artifacts are built AFTER you publish.
 
-**No action required** - Release Drafter maintains a single draft release that gets updated with each merge to master.
+**No action required** - Release Drafter maintains a single draft release that gets updated with each merge to main.
 
 ---
 
@@ -188,11 +188,11 @@ The **Sync VERSION on Release Publish** workflow:
 1. Extracts version from release tag
 2. Updates `VERSION` file if different
 3. Updates `internal/app/VERSION`
-4. Commits and pushes to master
+4. Commits and pushes to main
 
 **Duration**: ~10 seconds
 
-**Result**: VERSION file in master always matches the latest published release
+**Result**: VERSION file in main always matches the latest published release
 
 #### C. Update Docker Repository (~30 seconds, runs AFTER artifact build)
 
@@ -279,7 +279,7 @@ Release Drafter automatically categorizes PRs based on labels. Use these labels 
 
 | Workflow | Trigger | Purpose | Duration |
 |----------|---------|---------|----------|
-| `create-release.yml` | Push to master | Create/update draft release via Release Drafter | ~5 sec |
+| `create-release.yml` | Push to main | Create/update draft release via Release Drafter | ~5 sec |
 | `attach-artifact-release.yml` | Release published | Build and upload release artifacts | ~5-10 min |
 | `publish-release.yml` | Release published | Sync VERSION file after publish | ~10 sec |
 | `update-docker-repo.yml` | `attach-artifact-release.yml` completion | Update LPM in docker repository | ~30 sec |
@@ -343,12 +343,12 @@ If the automatic Docker update fails:
    echo "$VERSION" > VERSION
    git add VERSION
    git commit -m "Sync VERSION to $VERSION"
-   git push origin master
+   git push origin main
    ```
 
 ### Draft release not created
 
-**Problem:** No draft release after pushing to master.
+**Problem:** No draft release after pushing to main.
 
 **Solution:**
 1. Check the "Create Release" workflow logs
@@ -396,7 +396,7 @@ If all automation fails (extremely rare):
    echo "X.Y.Z" > VERSION
    git add VERSION
    git commit -m "Sync VERSION to X.Y.Z"
-   git push origin master
+   git push origin main
    ```
 
 ---
@@ -415,7 +415,7 @@ If all automation fails (extremely rare):
 - Publish releases without reviewing the changelog
 - Skip labeling PRs (affects versioning and categorization)
 - Delete tags without good reason
-- Force push to master
+- Force push to main
 
 ---
 
@@ -423,7 +423,7 @@ If all automation fails (extremely rare):
 
 | Step | Action | Duration | Manual? | Parallelism |
 |------|--------|----------|---------|-------------|
-| 1. | Merge PR to master | Instant | ✋ Manual | - |
+| 1. | Merge PR to main | Instant | ✋ Manual | - |
 | 2. | Release Drafter updates draft | ~5 sec | ✅ Auto | - |
 | 3. | Review and publish release | Variable | ✋ Manual | - |
 | 4. | Build artifacts | ~5-10 min | ✅ Auto | Parallel with step 5 |

--- a/internal/app/commands/update.go
+++ b/internal/app/commands/update.go
@@ -57,7 +57,7 @@ func init() {
 		&path,
 		"path",
 		"p",
-		"https://raw.githubusercontent.com/liquibase/liquibase-package-manager/master/internal/app/packages.json",
+		"https://raw.githubusercontent.com/liquibase/liquibase-package-manager/main/internal/app/packages.json",
 		"path to new packages.json manifest",
 	)
 }

--- a/tests/endtoend/update.yml
+++ b/tests/endtoend/update.yml
@@ -1,4 +1,4 @@
 tests:
   "can update package json from remote":
     command: lpm update
-    stdout: Package manifest updated from https://raw.githubusercontent.com/liquibase/liquibase-package-manager/master/internal/app/packages.json
+    stdout: Package manifest updated from https://raw.githubusercontent.com/liquibase/liquibase-package-manager/main/internal/app/packages.json


### PR DESCRIPTION
## Summary

Updates workflow triggers, release automation, documentation, and the default packages.json manifest URL to point at \`main\` in preparation for renaming the GitHub default branch.

- 5 workflows: \`codeql.yml\`, \`create-release.yml\`, \`test.yml\`, \`nightly-update-packages.yml\`, \`publish-release.yml\`
- 3 docs: \`README.md\`, \`RELEASING.md\`, \`CONTRIBUTING.md\` (ASCII box alignment preserved)
- Runtime: \`internal/app/commands/update.go\` default \`-p\` URL + matching \`tests/endtoend/update.yml\` stdout assertion

## Sequencing — important

This PR **must** be merged in coordination with the GitHub-side default-branch rename (\`Settings → Branches → Rename\`). Merging before the rename will cause:

- \`publish-release.yml\` to run \`git push origin main\` against a branch that doesn't exist → release publish fails mid-workflow
- \`test.yml\` and \`codeql.yml\` to stop triggering on pushes to \`master\` → CI silently skipped

Recommended order:
1. Merge this PR
2. Immediately rename default branch \`master\` → \`main\` in GitHub repo settings
3. Verify next push triggers CI

## Backward compatibility for installed lpm binaries

Previously-installed \`lpm\` binaries hit \`raw.githubusercontent.com/liquibase/liquibase-package-manager/master/internal/app/packages.json\`. GitHub's branch-rename alias continues serving that URL transparently after the rename (verified against \`rails/rails\` which has no \`master\` branch but serves the raw URL with HTTP 200, identical content). **No user communication required.**

## Context

Supersedes the previous premature push [3c128c8](https://github.com/liquibase/liquibase-package-manager/commit/3c128c828018b8224903ee53d6392b9fa26090fa), which went directly to \`master\` without review and is being reverted in #616.

## Test plan

- [ ] Merge #616 (revert) first to restore \`master\` baseline
- [ ] Merge this PR
- [ ] Rename GitHub default branch \`master\` → \`main\`
- [ ] Confirm next push to \`main\` triggers \`test.yml\` and \`codeql.yml\`
- [ ] Confirm \`curl -I https://raw.githubusercontent.com/liquibase/liquibase-package-manager/master/internal/app/packages.json\` still returns 200
- [ ] Confirm \`curl -I https://raw.githubusercontent.com/liquibase/liquibase-package-manager/main/internal/app/packages.json\` returns 200
- [ ] Next release publish: confirm \`publish-release.yml\` succeeds against \`main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)