### PR TITLE
Bump Go to 1.25.10 to patch 5 stdlib CVEs

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ">=1.25.9"
+          go-version: ">=1.25.10"
           cache: true
 
       - name: Update VERSION file

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
 
       # Symbol-level scan — fails build if code calls a vulnerable function
       - name: Run govulncheck (symbol-level)

--- a/.github/workflows/nightly-e2e-tests.yml
+++ b/.github/workflows/nightly-e2e-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '>=1.25.9'
+          go-version: '>=1.25.10'
 
       - name: Setup GO environment
         run: |

--- a/.github/workflows/nightly-update-packages.yml
+++ b/.github/workflows/nightly-update-packages.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ">=1.25.9"
+          go-version: ">=1.25.10"
 
       - name: Setup GO environment
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ">=1.25.9"
+          go-version: ">=1.25.10"
 
       - name: Setup GO environment
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ make test-search  # or test-add, test-install, etc.
 - Release automation via GitHub Actions
 
 ### Dependencies
-- **Go 1.25.9**: Primary language runtime
+- **Go 1.25.10**: Primary language runtime
 - **Cobra**: CLI framework and command structure
 - **go-version**: Semantic version handling
 - **oauth2**: GitHub API authentication for package discovery

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module package-manager
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/google/go-github/v39 v39.2.0


### PR DESCRIPTION
## Summary
- Bumps Go toolchain from 1.25.9 to 1.25.10 to patch 5 HIGH-severity stdlib CVEs (CVE-2026-33811, CVE-2026-33814, CVE-2026-39820, CVE-2026-39836, CVE-2026-42499)
- Follows the same pattern and file set as #613

## Context
Trivy (Docker Scout) flagged 5 stdlib vulnerabilities published 2026-05-07 in the compiled binary. All are fixed in Go 1.25.10.

| CVE | Severity | Fixed in |
|---|---|---|
| CVE-2026-33811 | HIGH | 1.25.10, 1.26.3 |
| CVE-2026-33814 | HIGH | 1.25.10, 1.26.3 |
| CVE-2026-39820 | HIGH | 1.25.10, 1.26.3 |
| CVE-2026-39836 | HIGH | 1.25.10, 1.26.3 |
| CVE-2026-42499 | HIGH | 1.25.10, 1.26.3 |

## Test plan
- [ ] CI test workflow passes
- [ ] CI govulncheck (symbol-level) — no vulnerabilities
- [ ] CI govulncheck (module-level) — no vulnerabilities after bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)