### PR TITLE
Fix populator nil pointer panic when version parsing fails

### DIFF
--- a/cmd/populator/artifactory_github.go
+++ b/cmd/populator/artifactory_github.go
@@ -30,10 +30,13 @@ func init() {
 // GetVersions from Github
 func (g Github) GetVersions(m Module) []*version.Version {
 	rr, _, _ := client.Repositories.ListReleases(context.Background(), m.owner, m.repo, &github.ListOptions{})
-	versions := make([]*version.Version, len(rr))
-	for i, r := range rr {
-		v, _ := version.NewVersion(r.GetTagName())
-		versions[i] = v
+	versions := make([]*version.Version, 0, len(rr))
+	for _, r := range rr {
+		v, err := version.NewVersion(r.GetTagName())
+		if err != nil {
+			continue
+		}
+		versions = append(versions, v)
 	}
 	sort.Sort(version.Collection(versions))
 	return versions

--- a/cmd/populator/artifactory_maven.go
+++ b/cmd/populator/artifactory_maven.go
@@ -65,10 +65,13 @@ func (mav Maven) GetVersions(m Module) []*version.Version {
 	}
 
 	// Sort Versions
-	versions := make([]*version.Version, len(versionsRaw))
-	for i, raw := range versionsRaw {
-		v, _ := version.NewVersion(raw)
-		versions[i] = v
+	versions := make([]*version.Version, 0, len(versionsRaw))
+	for _, raw := range versionsRaw {
+		v, err := version.NewVersion(raw)
+		if err != nil {
+			continue
+		}
+		versions = append(versions, v)
 	}
 	sort.Sort(version.Collection(versions))
 	return versions


### PR DESCRIPTION
## Summary
- `make generateExtensionPackages` started panicking after #607 bumped `hashicorp/go-version` to 1.9.0. The new release dereferences `*Version` in `Collection.Less` via `String()/bytes()`, so any nil entry in the sorted slice crashes the populator.
- Both `cmd/populator/artifactory_maven.go` and `cmd/populator/artifactory_github.go` were silently discarding the error from `version.NewVersion` and writing the resulting nil into the slice. Now they skip unparseable versions instead.

## Failure trace
```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/hashicorp/go-version.(*Version).bytes(0x0)
    .../go-version@v1.9.0/version.go:442
sort.Sort(...)
main.Maven.GetVersions(...)
    cmd/populator/artifactory_maven.go:73
```
Run: https://github.com/liquibase/liquibase-package-manager/actions/runs/25760140728/job/75658857887

## Test plan
- [ ] CI green on `Update Packages` workflow / populator-touching jobs
- [ ] `make generateExtensionPackages` runs to completion locally