### PR TITLE
Stop govulncheck-action from overriding pinned Go version

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -22,11 +22,16 @@ jobs:
         with:
           go-version: "1.25.10"
 
+      # Install govulncheck directly instead of using golang/govulncheck-action@v1.0.4,
+      # which internally re-runs setup-go with `go-version: stable` and silently scans
+      # against whatever Go is "stable" today — not the version this repo pins. That
+      # mismatch let 5 stdlib CVEs ship in #619 with the scan reporting "no vulns".
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
       # Symbol-level scan — fails build if code calls a vulnerable function
       - name: Run govulncheck (symbol-level)
-        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
-        with:
-          repo-checkout: false
+        run: govulncheck ./...
 
       # Module-level scan — fails build if any dependency has a known CVE (matches Docker Scout behavior).
       # -C cmd/lpm is required: -scan module does not accept package patterns (e.g. ./...), so

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -22,11 +22,16 @@ jobs:
         with:
           go-version: "1.25.11"
 
+      # Install govulncheck directly instead of using golang/govulncheck-action@v1.0.4,
+      # which internally re-runs setup-go with `go-version: stable` and silently scans
+      # against whatever Go is "stable" today — not the version this repo pins. That
+      # mismatch let 5 stdlib CVEs ship in #619 with the scan reporting "no vulns".
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
       # Symbol-level scan — fails build if code calls a vulnerable function
       - name: Run govulncheck (symbol-level)
-        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
-        with:
-          repo-checkout: false
+        run: govulncheck ./...
 
       # Module-level scan — fails build if any dependency has a known CVE (matches Docker Scout behavior).
       # -C cmd/lpm is required: -scan module does not accept package patterns (e.g. ./...), so


### PR DESCRIPTION
## Problem
`golang/govulncheck-action@v1.0.4` internally re-runs `setup-go` with `go-version: stable`, replacing the Go version we explicitly pinned. The module-level scan that follows it inherits the same `PATH`, so both scans end up running against \"whatever stable is today\" — not the Go we actually build with.

This silently masked the 5 stdlib CVEs that #619 had to patch by hand. Each scheduled scan reported \"No vulnerabilities found\" while the released binary was vulnerable; Trivy / Docker Scout caught the gap because they inspect the compiled binary's stdlib version.

Reproduced locally against the same module setup the CI uses:
```
GOTOOLCHAIN=go1.25.9 govulncheck -C cmd/sub -scan module
→ 8 vulnerabilities in stdlib@go1.25.9 (incl. all 5 from #619)
```
Run logs confirming the override on the 2026-05-12 nightly (pre-#619 merge):
```
Acquiring 1.26.3 from https://github.com/actions/go-versions/...
GOROOT='/opt/hostedtoolcache/go/1.26.3/x64'
...
No vulnerabilities found.
```
Workflow had asked for 1.25.9; scan ran against 1.26.3.

## Fix
Install govulncheck directly with `go install` and invoke it against the Go version that `actions/setup-go` set up. No transitive action, no surprise version override.

## Test plan
- [ ] CI on this PR: both `govulncheck ./...` and `govulncheck -C cmd/lpm -scan module` run against Go 1.25.10
- [ ] No vulnerabilities reported (1.25.10 is patched for the published stdlib CVEs)
- [ ] SARIF upload to GitHub Security tab still succeeds
- [ ] Next nightly run confirms the same