### PR TITLE
Re-enable postgresql Driver in populator

### DIFF
--- a/cmd/populator/modules.go
+++ b/cmd/populator/modules.go
@@ -159,13 +159,13 @@ func init() {
             url:         "https://repo1.maven.org/maven2/org/liquibase/ext/vaults/liquibase-hashicorp-vault",
             artifactory: Maven{},
         },
-        // {
-        //     name:          "postgresql",
-        //     category:      Driver,
-        //     url:           "https://repo1.maven.org/maven2/org/postgresql/postgresql",
-        //     excludeSuffix: ".jre",
-        //     artifactory:   Maven{},
-        // },
+        {
+            name:          "postgresql",
+            category:      Driver,
+            url:           "https://repo1.maven.org/maven2/org/postgresql/postgresql",
+            excludeSuffix: ".jre",
+            artifactory:   Maven{},
+        },
         {
             name:          "mssql",
             category:      Driver,


### PR DESCRIPTION
## Problem
The `postgresql` Driver entry in `cmd/populator/modules.go` was commented out in #495 (2025-02-28). No reason was recorded — empty PR description, terse \"Update modules.go\" commit message. Since then the populator has skipped postgres entirely, leaving `packages.json` frozen at 42.7.8 even though Maven Central has shipped six newer releases:

- 42.7.5, 42.7.6, 42.7.7 (missed before the comment-out and never picked up)
- 42.7.9, 42.7.10, 42.7.11 (published after the comment-out)

## Fix
Uncomment the original entry. No other changes.

## Local validation
Ran the populator against this branch:
```
postgresql: +['42.7.5', '42.7.6', '42.7.7', '42.7.9', '42.7.10', '42.7.11']
Total versions: 114 → 120
```
No other packages affected (with empty/dummy `GITHUB_PAT`; the production cron run will additionally pick up other Maven-side updates that are normal).

## Note for reviewers
The `nightly-update-packages.yml` workflow triggers on PRs touching `cmd/populator/**`, so a separate `[Automatic] Update packages.json` PR will appear with the data side of this change. That's the project's existing pattern (config and data live in separate PRs).

## Test plan
- [ ] CI green
- [ ] Auto-triggered `update/packages` PR includes the 6 missing postgres versions
- [ ] If we want to validate \"why was it disabled?\", a quick ping to @mcred / @StevenMassaro on #495 wouldn't hurt — but the artifacts on Maven look healthy and the populator handled them cleanly locally