### PR TITLE
Fix liquibase-mssql 5.0.2 checksum — replace Maven Central abuse-page text

### DIFF
--- a/internal/app/packages.json
+++ b/internal/app/packages.json
@@ -15497,7 +15497,7 @@
         "tag": "5.0.2",
         "path": "https://repo1.maven.org/maven2/org/liquibase/ext/liquibase-mssql/5.0.2/liquibase-mssql-5.0.2.jar",
         "algorithm": "SHA1",
-        "checksum": "This tool has been identified as abusive",
+        "checksum": "8e960aa6cf7c3ceaeae8e48ebfc1298845a8b8dd",
         "liquibaseCore": "5.0.2"
       }
     ]


### PR DESCRIPTION
## Summary

- Replace the poisoned checksum for `liquibase-mssql@5.0.2` in `internal/app/packages.json`.
- The old value (`"This tool has been identified as abusive"`) is Maven Central's anti-crawl response body, which the auto-updater captured verbatim in [PR #621](https://github.com/liquibase/liquibase-package-manager/pull/621) (auto-merged 2026-05-12 21:13 UTC).
- The correct SHA1 is `8e960aa6cf7c3ceaeae8e48ebfc1298845a8b8dd`, verified against the live Maven Central sidecar and by re-hashing the artifact locally.

## Reproduction (before this PR)

```bash
docker run --rm liquibase/liquibase lpm add liquibase-mssql
# Checksum validation failed. Aborting download.
```

## Verification

```bash
# Maven Central serves the correct SHA1 today
$ curl -sL https://repo1.maven.org/maven2/org/liquibase/ext/liquibase-mssql/5.0.2/liquibase-mssql-5.0.2.jar.sha1
8e960aa6cf7c3ceaeae8e48ebfc1298845a8b8dd

# Local SHA1 of the downloaded artifact matches
$ shasum -a 1 liquibase-mssql-5.0.2.jar
8e960aa6cf7c3ceaeae8e48ebfc1298845a8b8dd

# Sanity scan: no other entry has a non-hex SHA1 in packages.json
$ jq -r '[.[] | .versions[] | select(.algorithm=="SHA1" and (.checksum | test("^[0-9a-f]{40}$") | not)) | "\(.path) -> \(.checksum)"][]' internal/app/packages.json
(empty)
```

## Scope of impact

This is **only a data fix** to unblock `lpm update && lpm add liquibase-mssql`. Two things to be aware of:

1. **Existing LPM binaries** (e.g. the `liquibase/liquibase` Docker image) embed `packages.json` at build time via `//go:embed` in `internal/app/App.go`. They will continue to ship the stale checksum until LPM is rebuilt and downstream images are republished. End-users of the current image can work around this with `lpm update && lpm add liquibase-mssql` once this PR is merged.

2. **The auto-updater needs hardening** so a Maven Central abuse-page response can't poison `packages.json` again. Not in this PR — separate follow-up (recommended changes: validate captured checksum matches `^[0-9a-f]{40}$` for SHA1 / `^[0-9a-f]{64}$` for SHA256 before writing; recognize and retry-with-backoff on Maven Central's anti-crawl body; fail the update job if any captured value is invalid).

## Customer impact

Community user reported via support 2026-05-18 that `lpm add liquibase-mssql` on `liquibase/liquibase:latest` has been failing for ~5 days. Tracked in **TECHOPS-458**: https://datical.atlassian.net/browse/TECHOPS-458

## Test plan

- [x] `internal/app/packages.json` diff is exactly one line (the mssql 5.0.2 checksum).
- [x] Maven Central currently serves the new value at the corresponding `.sha1` URL.
- [x] Re-downloaded the JAR and confirmed `shasum -a 1` matches the new value.
- [x] No other SHA1 entry in `packages.json` is non-hex (full file scanned).
- [ ] Rebuild LPM with this change embedded and confirm `lpm add liquibase-mssql` succeeds end-to-end.

Refs: TECHOPS-458