### PR TITLE
TECHOPS-603: Fan out LPM version/checksum updates to all consumer repos

### DIFF
--- a/.github/workflows/README-docker-update.md
+++ b/.github/workflows/README-docker-update.md
@@ -23,8 +23,7 @@ Trigger (workflow_run success | workflow_dispatch)
   │
   ├─ update-repo      (needs: prepare, fail-fast: false)
   │    ├─ liquibase/liquibase job
-  │    ├─ liquibase/liquibase-pro job   ← see P1/P2 notes below
-  │    └─ liquibase/docker job          ← TODO: remove after TECHOPS-366
+  │    └─ liquibase/liquibase-pro job   ← see P1/P2 notes below
   │
   └─ summary          (needs: [prepare, update-repo], if: always())
 ```
@@ -40,7 +39,6 @@ via a job output — job outputs are not treated as secrets and can leak in logs
 |------|---------------|
 | `liquibase/liquibase` | `docker/Dockerfile` `docker/Dockerfile.alpine` |
 | `liquibase/liquibase-pro` | `core/docker/Dockerfile` `core/docker/Dockerfile.alpine` `docker/Dockerfile` *(placeholder — confirm P1 before first release)* |
-| `liquibase/docker` | `Dockerfile` `Dockerfile.alpine` `DockerfileSecure` *(TODO: remove after TECHOPS-366)* |
 
 Each matrix entry has two fields: `repo` and `files` (space-delimited list of paths
 relative to the repo root). No other workflow logic needs to change when the list changes.
@@ -63,9 +61,6 @@ That's the only change required (R9).
 ## How to remove a consumer repo
 
 Delete its `include` entry from the matrix. No other YAML changes are needed.
-
-For `liquibase/docker` specifically, removal is tracked in **TECHOPS-366** and should
-happen when that repo is archived.
 
 ---
 
@@ -101,7 +96,7 @@ means the file set in the matrix is wrong (**P1**).
 The matrix runs with `fail-fast: false`. This means:
 
 - If `liquibase/liquibase-pro` fails (e.g. a 403 because the App is not installed),
-  the `liquibase/liquibase` and `liquibase/docker` jobs still run and open their PRs.
+  the `liquibase/liquibase` job still runs and opens its PR.
 - The overall workflow run is marked **failed** if ANY matrix job fails. This is
   **intentional alerting** — not a bug. Check the Summary tab for the per-repo breakdown.
 

--- a/.github/workflows/README-docker-update.md
+++ b/.github/workflows/README-docker-update.md
@@ -16,7 +16,7 @@ isolated job, so a failure in one repo never blocks the others.
 
 ## Workflow structure
 
-```
+```text
 Trigger (workflow_run success | workflow_dispatch)
   │
   ├─ prepare          (runs once — resolves version + checksums)
@@ -180,4 +180,4 @@ not be shortened.
 If the consumer list grows large or needs to be shared across multiple workflows,
 the inline matrix can be replaced with an external `consumers.json` file and a
 `fromJSON(steps.load.outputs.matrix)` dynamic matrix. This is not needed at the
-current scale of 3–4 repos.
+current scale of 2 repos.

--- a/.github/workflows/README-docker-update.md
+++ b/.github/workflows/README-docker-update.md
@@ -23,7 +23,7 @@ Trigger (workflow_run success | workflow_dispatch)
   │
   ├─ update-repo      (needs: prepare, fail-fast: false)
   │    ├─ liquibase/liquibase job
-  │    └─ liquibase/liquibase-pro job   ← see P1/P2 notes below
+  │    └─ liquibase/liquibase-pro job   ← see P2 note below
   │
   └─ summary          (needs: [prepare, update-repo], if: always())
 ```
@@ -38,7 +38,7 @@ via a job output — job outputs are not treated as secrets and can leak in logs
 | Repo | Files updated |
 |------|---------------|
 | `liquibase/liquibase` | `docker/Dockerfile` `docker/Dockerfile.alpine` |
-| `liquibase/liquibase-pro` | `core/docker/Dockerfile` `core/docker/Dockerfile.alpine` `docker/Dockerfile` *(placeholder — confirm P1 before first release)* |
+| `liquibase/liquibase-pro` | `docker/Dockerfile` *(`core/docker/*` is legacy — intentionally NOT updated)* |
 
 Each matrix entry has two fields: `repo` and `files` (space-delimited list of paths
 relative to the repo root). No other workflow logic needs to change when the list changes.
@@ -86,8 +86,7 @@ against the real target repos without opening any PRs:
 5. The Summary tab shows `dry-run-would-create` or `noop` per repo.
 
 A dry-run that returns a 403 on a checkout confirms the GitHub App is not installed
-on that repo (**P2 blocker**). A dry-run with an empty or wrong diff on `liquibase-pro`
-means the file set in the matrix is wrong (**P1**).
+on that repo (**P2 blocker**).
 
 ---
 
@@ -115,14 +114,13 @@ repo with `contents: write` and `pull-requests: write`. This is required on
 Fastest confirmation: run a `dry-run` dispatch. A 403 on checkout means the App is
 not yet installed.
 
-### P1 (MED — blocks liquibase-pro job)
+### liquibase-pro live file set (confirmed)
 
-The exact live Dockerfile set for `liquibase/liquibase-pro` is unconfirmed. The current
-placeholder (`core/docker/Dockerfile`, `core/docker/Dockerfile.alpine`, `docker/Dockerfile`)
-must be verified against the actual repo by someone with read access, then updated in the
-matrix `files` field before merging.
+`liquibase/liquibase-pro` updates **only `docker/Dockerfile`**. The `core/docker/`
+Dockerfiles are **legacy and must NOT be added** to the matrix — they are intentionally
+left unmanaged.
 
-The workflow will fail loudly on a missing file (`::error::` annotation + exit 1), so a
+The workflow fails loudly on a missing file (`::error::` annotation + exit 1), so a
 wrong path breaks only the `liquibase-pro` job — other repos are unaffected.
 
 ---
@@ -162,7 +160,7 @@ not be shortened.
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | Job fails with 403 on checkout | GitHub App not installed on target repo | Confirm P2: install App with `contents:write` + `pull-requests:write` |
-| `Listed file not found: path/to/Dockerfile` | Matrix `files` has a wrong path | Confirm P1: update matrix entry to the actual live file paths |
+| `Listed file not found: path/to/Dockerfile` | Matrix `files` has a wrong path | Update the matrix entry to the actual live file path |
 | `Invalid or missing SHA256` | checksums.txt entry not found, or value not 64 hex chars | Check release assets contain `checksums.txt`; or supply overrides via dispatch inputs |
 | Overall run failed, some repos got PRs | `fail-fast:false` — one job failed, others continued | Check Summary tab for the failed repo; the partial result is the intended behavior |
 | "No changes detected" for a repo | That repo is already at the target version | Expected no-op; no action needed |

--- a/.github/workflows/README-docker-update.md
+++ b/.github/workflows/README-docker-update.md
@@ -54,7 +54,7 @@ Add one entry to the `strategy.matrix.include` list in `update-docker-repo.yml`:
   files: "path/to/Dockerfile path/to/Dockerfile.alpine"
 ```
 
-That's the only change required (R9).
+That's the only change required.
 
 ---
 

--- a/.github/workflows/README-docker-update.md
+++ b/.github/workflows/README-docker-update.md
@@ -1,156 +1,190 @@
-# Docker Repository Auto-Update
+# Docker Repository Auto-Update — Consumer Fanout
 
-This workflow automatically updates the LPM version in the `liquibase/docker` repository when a new LPM release is published.
+When a new LPM release is published, this workflow automatically propagates the updated version
+and checksums to every consumer Docker repository in one run. Each consumer repo gets its own
+isolated job, so a failure in one repo never blocks the others.
 
-## How It Works
+## Quick path
 
-### Automatic Trigger (Recommended)
+1. Publish a new LPM release (or dispatch manually).
+2. The `prepare` job resolves the version and validates both SHA256 checksums.
+3. The `update-repo` matrix job fans out — one job per consumer repo.
+4. Each job opens a PR in its target repo (or records "no-op" if already up to date).
+5. The `summary` job renders a per-repo outcome table in the run's Step Summary.
 
-When you **publish** a release in the `liquibase-package-manager` repository:
+---
 
-1. The workflow automatically runs
-2. Extracts the version from the release tag
-3. Downloads the `checksums.txt` file from the release
-4. Extracts SHA256 checksums for `linux-amd64` and `linux-arm64`
-5. Updates three Dockerfiles in the `liquibase/docker` repository:
-   - `Dockerfile`
-   - `Dockerfile.alpine`
-   - `DockerfileSecure`
-6. Creates a PR in the docker repository
+## Workflow structure
 
-### Manual Trigger
+```
+Trigger (workflow_run success | workflow_dispatch)
+  │
+  ├─ prepare          (runs once — resolves version + checksums)
+  │
+  ├─ update-repo      (needs: prepare, fail-fast: false)
+  │    ├─ liquibase/liquibase job
+  │    ├─ liquibase/liquibase-pro job   ← see P1/P2 notes below
+  │    └─ liquibase/docker job          ← TODO: remove after TECHOPS-366
+  │
+  └─ summary          (needs: [prepare, update-repo], if: always())
+```
 
-You can also manually trigger the workflow:
+The GitHub App token is **re-minted inside each matrix job**. It is never passed
+via a job output — job outputs are not treated as secrets and can leak in logs.
 
-1. Go to **Actions** → **Update Docker Repository with New LPM Version**
-2. Click **Run workflow**
-3. Enter:
-   - **lpm-version**: Version without 'v' prefix (e.g., `0.2.15`)
-   - **sha256-amd64**: (Optional) Leave empty to auto-fetch from release
-   - **sha256-arm64**: (Optional) Leave empty to auto-fetch from release
-4. Click **Run workflow**
+---
 
-## Prerequisites
+## Consumer matrix
 
-### Required Secret
+| Repo | Files updated |
+|------|---------------|
+| `liquibase/liquibase` | `docker/Dockerfile` `docker/Dockerfile.alpine` |
+| `liquibase/liquibase-pro` | `core/docker/Dockerfile` `core/docker/Dockerfile.alpine` `docker/Dockerfile` *(placeholder — confirm P1 before first release)* |
+| `liquibase/docker` | `Dockerfile` `Dockerfile.alpine` `DockerfileSecure` *(TODO: remove after TECHOPS-366)* |
 
-The workflow requires a `BOT_TOKEN` secret with:
-- Write access to the `liquibase/docker` repository
-- Ability to create branches and pull requests
+Each matrix entry has two fields: `repo` and `files` (space-delimited list of paths
+relative to the repo root). No other workflow logic needs to change when the list changes.
 
-To set up the token:
+---
 
-1. Create a GitHub Personal Access Token (classic) or Fine-grained token with:
-   - Repository access: `liquibase/docker`
-   - Permissions: `Contents: Read and Write`, `Pull Requests: Read and Write`
-2. Add it as a repository secret named `BOT_TOKEN` in the `liquibase-package-manager` repository
+## How to add a consumer repo
 
-## What Gets Updated
+Add one entry to the `strategy.matrix.include` list in `update-docker-repo.yml`:
 
-### Dockerfile Variables
+```yaml
+- repo: org/repo-name
+  files: "path/to/Dockerfile path/to/Dockerfile.alpine"
+```
 
-In each Dockerfile, three ARG variables are updated:
+That's the only change required (R9).
+
+---
+
+## How to remove a consumer repo
+
+Delete its `include` entry from the matrix. No other YAML changes are needed.
+
+For `liquibase/docker` specifically, removal is tracked in **TECHOPS-366** and should
+happen when that repo is archived.
+
+---
+
+## Workflow inputs (workflow_dispatch)
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `lpm-version` | Yes | — | Version without `v` prefix (e.g. `0.3.5`) |
+| `sha256-amd64` | No | *(auto-fetched)* | Override SHA256 for `linux-amd64`; leave empty to fetch from release |
+| `sha256-arm64` | No | *(auto-fetched)* | Override SHA256 for `linux-arm64`; leave empty to fetch from release |
+| `dry-run` | No | `false` | Show diff and skip PR creation — use this to test without side effects |
+
+### Dry-run usage
+
+The `dry-run` input lets you validate the full pipeline (checkout, sed, git diff)
+against the real target repos without opening any PRs:
+
+1. Go to **Actions → Update Docker Repository with New LPM Version → Run workflow**.
+2. Set `lpm-version` to a known released version (e.g. `0.3.5`).
+3. Set `dry-run: true`.
+4. Each matrix job will check out the repo, run the sed updates, and print the diff
+   (or "already up to date") — but will not create a PR.
+5. The Summary tab shows `dry-run-would-create` or `noop` per repo.
+
+A dry-run that returns a 403 on a checkout confirms the GitHub App is not installed
+on that repo (**P2 blocker**). A dry-run with an empty or wrong diff on `liquibase-pro`
+means the file set in the matrix is wrong (**P1**).
+
+---
+
+## Partial-failure semantics
+
+The matrix runs with `fail-fast: false`. This means:
+
+- If `liquibase/liquibase-pro` fails (e.g. a 403 because the App is not installed),
+  the `liquibase/liquibase` and `liquibase/docker` jobs still run and open their PRs.
+- The overall workflow run is marked **failed** if ANY matrix job fails. This is
+  **intentional alerting** — not a bug. Check the Summary tab for the per-repo breakdown.
+
+Do not mistake a partial run for a complete success just because some repos got PRs.
+
+---
+
+## Preconditions before first real release
+
+### P2 (HIGH — blocks all private-repo jobs)
+
+The Liquibase GitHub App (`LIQUIBASE_GITHUB_APP_ID`) must be installed on every target
+repo with `contents: write` and `pull-requests: write`. This is required on
+`liquibase/liquibase-pro` (private) in particular.
+
+Fastest confirmation: run a `dry-run` dispatch. A 403 on checkout means the App is
+not yet installed.
+
+### P1 (MED — blocks liquibase-pro job)
+
+The exact live Dockerfile set for `liquibase/liquibase-pro` is unconfirmed. The current
+placeholder (`core/docker/Dockerfile`, `core/docker/Dockerfile.alpine`, `docker/Dockerfile`)
+must be verified against the actual repo by someone with read access, then updated in the
+matrix `files` field before merging.
+
+The workflow will fail loudly on a missing file (`::error::` annotation + exit 1), so a
+wrong path breaks only the `liquibase-pro` job — other repos are unaffected.
+
+---
+
+## Out-of-scope repos
+
+The following repos pin an older LPM version intentionally and are **not managed by this
+workflow**. Do not add them to the matrix.
+
+| Repo | Pinned LPM version | Reason |
+|------|--------------------|--------|
+| `liquibase/liquibase-test-harness` | 0.2.3 | Test infra; version pinned by test team |
+| `liquibase/mongodemo` | 0.2.0 | Demo repo; version pinned intentionally |
+| `liquibase/flow-demo` | 0.1.7 | Demo repo; version pinned intentionally |
+| `liquibase/devops-misc` | 0.1.3 | Infra repo; version pinned intentionally |
+
+---
+
+## What gets updated in each Dockerfile
+
+Three `ARG` lines are updated per file:
 
 ```dockerfile
-ARG LPM_VERSION=0.2.15
+ARG LPM_VERSION=<version>
 ARG LPM_SHA256=<sha256 for linux-amd64>
 ARG LPM_SHA256_ARM=<sha256 for linux-arm64>
 ```
 
-### Files Updated
+The `^ARG LPM_SHA256=` sed pattern matches the amd64 line only. The trailing `=` is
+a boundary that cannot match `LPM_SHA256_ARM=` — the anchor is load-bearing and must
+not be shortened.
 
-- `Dockerfile` - Standard Ubuntu-based image
-- `Dockerfile.alpine` - Alpine Linux-based image
-- `DockerfileSecure` - Secure/licensed image
-
-## PR Details
-
-The automatically created PR includes:
-
-- **Title**: `Update LPM to v{version}`
-- **Labels**: `lpm`, `dependencies`, `automated`
-- **Description**: 
-  - Version being updated
-  - SHA256 checksums for both architectures
-  - List of files changed
-  - Link to the LPM release
-  - Verification notes
+---
 
 ## Troubleshooting
 
-### "checksums.txt not found"
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Job fails with 403 on checkout | GitHub App not installed on target repo | Confirm P2: install App with `contents:write` + `pull-requests:write` |
+| `Listed file not found: path/to/Dockerfile` | Matrix `files` has a wrong path | Confirm P1: update matrix entry to the actual live file paths |
+| `Invalid or missing SHA256` | checksums.txt entry not found, or value not 64 hex chars | Check release assets contain `checksums.txt`; or supply overrides via dispatch inputs |
+| Overall run failed, some repos got PRs | `fail-fast:false` — one job failed, others continued | Check Summary tab for the failed repo; the partial result is the intended behavior |
+| "No changes detected" for a repo | That repo is already at the target version | Expected no-op; no action needed |
+| PR already exists on branch `update-lpm-<version>` | Workflow re-triggered for same version | `peter-evans/create-pull-request` updates the existing PR; no duplicate |
 
-**Cause**: The checksums file wasn't uploaded to the release.
+---
 
-**Solution**: Ensure the "Attach Artifact to Release" workflow completes successfully before publishing.
+## Related workflows
 
-### "Invalid SHA256"
+- `attach-artifact-release.yml` — generates `checksums.txt` (must succeed before this workflow runs)
+- `publish-release.yml` — syncs the internal VERSION file after a release
 
-**Cause**: Checksum doesn't match expected format (64 characters).
+---
 
-**Solution**: 
-1. Check that `checksums.txt` contains valid checksums
-2. Manually trigger the workflow with correct checksums
+## Future options (deferred)
 
-### "No changes detected"
-
-**Cause**: Docker repository already has the same version/checksums.
-
-**Solution**: This is expected if the version was already updated. No action needed.
-
-### "PR creation failed"
-
-**Cause**: Missing or invalid `BOT_TOKEN` secret.
-
-**Solution**:
-1. Verify `BOT_TOKEN` is configured in repository secrets
-2. Check token has correct permissions
-3. Ensure token hasn't expired
-
-## Manual Update (Fallback)
-
-If automation fails, you can manually update the docker repository:
-
-```bash
-# Clone docker repository
-git clone https://github.com/liquibase/docker.git
-cd docker
-
-# Update version and checksums
-VERSION="0.2.15"
-SHA256_AMD64="..."  # Get from release
-SHA256_ARM64="..."  # Get from release
-
-# Update all Dockerfiles
-for file in Dockerfile Dockerfile.alpine DockerfileSecure; do
-  sed -i "s/^ARG LPM_VERSION=.*/ARG LPM_VERSION=${VERSION}/" $file
-  sed -i "s/^ARG LPM_SHA256=.*/ARG LPM_SHA256=${SHA256_AMD64}/" $file
-  sed -i "s/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM=${SHA256_ARM64}/" $file
-done
-
-# Create branch and PR
-git checkout -b update-lpm-${VERSION}
-git add Dockerfile Dockerfile.alpine DockerfileSecure
-git commit -m "Update LPM to version ${VERSION}"
-git push origin update-lpm-${VERSION}
-# Then create PR on GitHub
-```
-
-## Testing
-
-To test the workflow without creating a real PR:
-
-1. Fork the `liquibase/docker` repository to your account
-2. Update the workflow to use your fork:
-   ```yaml
-   repository: YOUR_USERNAME/docker
-   ```
-3. Run the workflow manually
-4. Verify the PR is created in your fork
-5. Review changes and delete the test PR
-
-## Related Workflows
-
-- `attach-artifact-release.yml` - Generates the checksums file
-- `publish-release.yml` - Syncs VERSION file after release
-- Both run before this workflow in the release process
+If the consumer list grows large or needs to be shared across multiple workflows,
+the inline matrix can be replaced with an external `consumers.json` file and a
+`fromJSON(steps.load.outputs.matrix)` dynamic matrix. This is not needed at the
+current scale of 3–4 repos.

--- a/.github/workflows/update-docker-repo.yml
+++ b/.github/workflows/update-docker-repo.yml
@@ -19,18 +19,138 @@ on:
         description: "SHA256 for linux-arm64 (leave empty to fetch from release)"
         required: false
         type: string
+      dry-run:
+        description: "Update + show diff but DO NOT open PRs"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
-  id-token: write
+  id-token: write  # Required for AWS OIDC in every job
 
 jobs:
-  update-docker-repo:
-    name: Update LPM in Docker Repository
+  # ─── Stage 1: Compute version + checksums ONCE ───────────────────────────────
+  # This job uses only GITHUB_TOKEN (read-only) to read public release data.
+  # The GitHub App token is re-minted per matrix job and NEVER emitted as output.
+  prepare:
+    name: Prepare version and checksums
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      version:      ${{ steps.version.outputs.version }}
+      sha256_amd64: ${{ steps.checksums.outputs.sha256_amd64 }}
+      sha256_arm64: ${{ steps.checksums.outputs.sha256_arm64 }}
 
     steps:
+      - name: Extract version from release
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            # Get the latest published release tag for this repo
+            TAG_NAME=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/${{ github.repository }}/releases \
+              --jq 'sort_by(.published_at) | reverse | .[0].tag_name')
+            VERSION="${TAG_NAME#v}"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "Using version from latest release: $VERSION"
+          else
+            VERSION="${{ inputs.lpm-version }}"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "Using manual input version: $VERSION"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download checksums file
+        id: download-checksums
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Download checksums.txt from release
+          echo "Downloading checksums for version $VERSION..."
+          if ! curl -sfL -o checksums.txt \
+            "https://github.com/liquibase/liquibase-package-manager/releases/download/v${VERSION}/checksums.txt"; then
+            echo "Direct download failed. Trying release assets API..."
+
+            # Fallback: resolve the asset URL via the GitHub releases API
+            curl -sfL -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/liquibase/liquibase-package-manager/releases/tags/v${VERSION}" \
+              > release.json
+
+            CHECKSUMS_URL=$(jq -r '.assets[] | select(.name == "checksums.txt") | .browser_download_url' release.json)
+
+            if [ -n "$CHECKSUMS_URL" ] && [ "$CHECKSUMS_URL" != "null" ]; then
+              curl -sfL -o checksums.txt "$CHECKSUMS_URL"
+            else
+              echo "::error::checksums.txt not found in release assets for v${VERSION}"
+              exit 1
+            fi
+          fi
+
+          echo "Downloaded checksums.txt:"
+          cat checksums.txt
+
+      - name: Extract and validate SHA256 checksums
+        id: checksums
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Use dispatch overrides when BOTH are supplied; otherwise parse from checksums.txt
+          if [ -n "${{ inputs.sha256-amd64 }}" ] && [ -n "${{ inputs.sha256-arm64 }}" ]; then
+            SHA256_AMD64="${{ inputs.sha256-amd64 }}"
+            SHA256_ARM64="${{ inputs.sha256-arm64 }}"
+            echo "Using manually supplied SHA256 overrides"
+          else
+            SHA256_AMD64=$(grep "lpm-${VERSION}-linux.zip" checksums.txt | awk '{print $1}')
+            SHA256_ARM64=$(grep "lpm-${VERSION}-linux-arm64.zip" checksums.txt | awk '{print $1}')
+
+            # Fall back to individual override if only one was supplied
+            if [ -n "${{ inputs.sha256-amd64 }}" ]; then
+              SHA256_AMD64="${{ inputs.sha256-amd64 }}"
+            fi
+            if [ -n "${{ inputs.sha256-arm64 }}" ]; then
+              SHA256_ARM64="${{ inputs.sha256-arm64 }}"
+            fi
+          fi
+
+          # Each SHA must be exactly 64 hex chars — anything else aborts all matrix jobs
+          if [ -z "$SHA256_AMD64" ] || ! echo "$SHA256_AMD64" | grep -qE '^[0-9a-f]{64}$'; then
+            echo "::error::Invalid or missing SHA256 for amd64 (got: '$SHA256_AMD64'). Expected exactly 64 hex characters."
+            exit 1
+          fi
+          if [ -z "$SHA256_ARM64" ] || ! echo "$SHA256_ARM64" | grep -qE '^[0-9a-f]{64}$'; then
+            echo "::error::Invalid or missing SHA256 for arm64 (got: '$SHA256_ARM64'). Expected exactly 64 hex characters."
+            exit 1
+          fi
+
+          echo "sha256_amd64=$SHA256_AMD64" >> "$GITHUB_OUTPUT"
+          echo "sha256_arm64=$SHA256_ARM64" >> "$GITHUB_OUTPUT"
+          echo "SHA256 checksums validated (amd64: ${SHA256_AMD64:0:8}..., arm64: ${SHA256_ARM64:0:8}...)"
+
+  # ─── Stage 2: Fan out — one job per consumer repo ────────────────────────────
+  # Token is RE-MINTED here per job. It is NEVER passed as a job output.
+  # See TECHOPS-603 design Decision 1: credentials must not cross job boundaries.
+  update-repo:
+    name: "Update ${{ matrix.repo }}"
+    needs: prepare
+    runs-on: ubuntu-latest
+    if: ${{ needs.prepare.result == 'success' }}
+    strategy:
+      fail-fast: false  # One repo failing must not cancel others (R6)
+      matrix:
+        include:
+          - repo: liquibase/liquibase
+            files: "docker/Dockerfile docker/Dockerfile.alpine"
+          - repo: liquibase/liquibase-pro  # PRIVATE — needs App install (P2) + live-file confirm (P1)
+            files: "core/docker/Dockerfile core/docker/Dockerfile.alpine docker/Dockerfile"
+          - repo: liquibase/docker  # TODO: remove after TECHOPS-366 archives this repo
+            files: "Dockerfile Dockerfile.alpine DockerfileSecure"
+
+    steps:
+      # Token re-minted here per-job — never passed via job output (see TECHOPS-603 design Decision 1)
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
@@ -46,231 +166,173 @@ jobs:
           parse-json-secrets: true
 
       - name: Get GitHub App token
-        id: get-token
+        id: app-token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
-      - name: Extract version from release
-        id: version
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            # Get the release that triggered the upstream workflow
-            TAG_NAME=$(gh api \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              /repos/${{ github.repository }}/releases \
-              --jq 'sort_by(.published_at) | reverse | .[0].tag_name')
-            VERSION="${TAG_NAME#v}"
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "Using version from latest release: $VERSION"
-          else
-            VERSION="${{ inputs.lpm-version }}"
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "Using manual input version: $VERSION"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download checksums file
-        id: download-checksums
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
-          # Download checksums.txt from release
-          echo "Downloading checksums for version $VERSION..."
-          curl -sfL -o checksums.txt \
-            "https://github.com/liquibase/liquibase-package-manager/releases/download/v${VERSION}/checksums.txt"
-
-          if [ $? -ne 0 ]; then
-            echo "❌ Failed to download checksums.txt"
-            echo "Trying to fetch from release assets..."
-            
-            # Fallback: try to get checksums from release API
-            curl -sfL -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              "https://api.github.com/repos/liquibase/liquibase-package-manager/releases/tags/v${VERSION}" \
-              > release.json
-            
-            CHECKSUMS_URL=$(jq -r '.assets[] | select(.name == "checksums.txt") | .browser_download_url' release.json)
-            
-            if [ -n "$CHECKSUMS_URL" ] && [ "$CHECKSUMS_URL" != "null" ]; then
-              curl -sfL -o checksums.txt "$CHECKSUMS_URL"
-            else
-              echo "❌ checksums.txt not found in release assets"
-              exit 1
-            fi
-          fi
-
-          echo "✅ Downloaded checksums.txt"
-          cat checksums.txt
-
-      - name: Extract SHA256 checksums
-        id: checksums
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
-          # Use manual input if provided, otherwise extract from checksums.txt
-          if [ -n "${{ inputs.sha256-amd64 }}" ]; then
-            SHA256_AMD64="${{ inputs.sha256-amd64 }}"
-            echo "Using manual SHA256 for amd64: $SHA256_AMD64"
-          else
-            SHA256_AMD64=$(grep "lpm-${VERSION}-linux.zip" checksums.txt | awk '{print $1}')
-            echo "Extracted SHA256 for amd64: $SHA256_AMD64"
-          fi
-
-          if [ -n "${{ inputs.sha256-arm64 }}" ]; then
-            SHA256_ARM64="${{ inputs.sha256-arm64 }}"
-            echo "Using manual SHA256 for arm64: $SHA256_ARM64"
-          else
-            SHA256_ARM64=$(grep "lpm-${VERSION}-linux-arm64.zip" checksums.txt | awk '{print $1}')
-            echo "Extracted SHA256 for arm64: $SHA256_ARM64"
-          fi
-
-          # Validate checksums
-          if [ -z "$SHA256_AMD64" ] || [ ${#SHA256_AMD64} -ne 64 ]; then
-            echo "❌ Invalid SHA256 for amd64: $SHA256_AMD64"
-            exit 1
-          fi
-
-          if [ -z "$SHA256_ARM64" ] || [ ${#SHA256_ARM64} -ne 64 ]; then
-            echo "❌ Invalid SHA256 for arm64: $SHA256_ARM64"
-            exit 1
-          fi
-
-          echo "sha256_amd64=$SHA256_AMD64" >> $GITHUB_OUTPUT
-          echo "sha256_arm64=$SHA256_ARM64" >> $GITHUB_OUTPUT
-
-          echo "✅ SHA256 checksums validated"
-
-      - name: Checkout docker repository
+      - name: Checkout ${{ matrix.repo }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: liquibase/docker
+          repository: ${{ matrix.repo }}
           ref: main
-          token: ${{ steps.get-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
 
-      - name: Update Dockerfile
+      - name: Update LPM ARGs in Dockerfiles
+        env:
+          VERSION:      ${{ needs.prepare.outputs.version }}
+          SHA256_AMD64: ${{ needs.prepare.outputs.sha256_amd64 }}
+          SHA256_ARM64: ${{ needs.prepare.outputs.sha256_arm64 }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          SHA256_AMD64="${{ steps.checksums.outputs.sha256_amd64 }}"
-          SHA256_ARM64="${{ steps.checksums.outputs.sha256_arm64 }}"
-
-          echo "Updating Dockerfile..."
-          sed -i "s/^ARG LPM_VERSION=.*/ARG LPM_VERSION=${VERSION}/" Dockerfile
-          sed -i "s/^ARG LPM_SHA256=.*/ARG LPM_SHA256=${SHA256_AMD64}/" Dockerfile
-          sed -i "s/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM=${SHA256_ARM64}/" Dockerfile
-
-          echo "✅ Updated Dockerfile"
-          grep -A 2 "ARG LPM_VERSION" Dockerfile
-
-      - name: Update Dockerfile.alpine
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          SHA256_AMD64="${{ steps.checksums.outputs.sha256_amd64 }}"
-          SHA256_ARM64="${{ steps.checksums.outputs.sha256_arm64 }}"
-
-          echo "Updating Dockerfile.alpine..."
-          sed -i "s/^ARG LPM_VERSION=.*/ARG LPM_VERSION=${VERSION}/" Dockerfile.alpine
-          sed -i "s/^ARG LPM_SHA256=.*/ARG LPM_SHA256=${SHA256_AMD64}/" Dockerfile.alpine
-          sed -i "s/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM=${SHA256_ARM64}/" Dockerfile.alpine
-
-          echo "✅ Updated Dockerfile.alpine"
-          grep -A 2 "ARG LPM_VERSION" Dockerfile.alpine
-
-      - name: Update DockerfileSecure
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          SHA256_AMD64="${{ steps.checksums.outputs.sha256_amd64 }}"
-          SHA256_ARM64="${{ steps.checksums.outputs.sha256_arm64 }}"
-
-          echo "Updating DockerfileSecure..."
-          sed -i "s/^ARG LPM_VERSION=.*/ARG LPM_VERSION=${VERSION}/" DockerfileSecure
-          sed -i "s/^ARG LPM_SHA256=.*/ARG LPM_SHA256=${SHA256_AMD64}/" DockerfileSecure
-          sed -i "s/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM=${SHA256_ARM64}/" DockerfileSecure
-
-          echo "✅ Updated DockerfileSecure"
-          grep -A 2 "ARG LPM_VERSION" DockerfileSecure
+          set -euo pipefail
+          for f in ${{ matrix.files }}; do
+            if [ ! -f "$f" ]; then
+              echo "::error::Listed file not found: $f (check matrix files[] for ${{ matrix.repo }})"
+              exit 1
+            fi
+            # NOTE: ^ARG LPM_SHA256= matches amd64 ONLY — the trailing = cannot match
+            # LPM_SHA256_ARM= (which has _ARM before the =). The = boundary is load-bearing.
+            sed -i "s/^ARG LPM_VERSION=.*/ARG LPM_VERSION=${VERSION}/"            "$f"
+            sed -i "s/^ARG LPM_SHA256=.*/ARG LPM_SHA256=${SHA256_AMD64}/"         "$f"
+            sed -i "s/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM=${SHA256_ARM64}/" "$f"
+            echo "Updated $f:"
+            grep -E "^ARG LPM_(VERSION|SHA256|SHA256_ARM)=" "$f"
+          done
 
       - name: Check for changes
-        id: check-changes
+        id: check
         run: |
           if git diff --quiet; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-            echo "⚠️ No changes detected"
+            echo "outcome=noop" >> "$GITHUB_OUTPUT"
+            echo "No changes for ${{ matrix.repo }} — already up to date"
           else
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "✅ Changes detected"
-            echo "=== Changes ==="
+            echo "outcome=changed" >> "$GITHUB_OUTPUT"
             git diff
           fi
 
+      - name: Build PR body
+        id: body
+        if: steps.check.outputs.outcome == 'changed'
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          SHA256_AMD64="${{ needs.prepare.outputs.sha256_amd64 }}"
+          SHA256_ARM64="${{ needs.prepare.outputs.sha256_arm64 }}"
+          {
+            echo "Updates LPM to **v${VERSION}** in \`${{ matrix.repo }}\`."
+            echo
+            echo "- **LPM_VERSION:** \`${VERSION}\`"
+            echo "- **LPM_SHA256 (amd64):** \`${SHA256_AMD64}\`"
+            echo "- **LPM_SHA256_ARM (arm64):** \`${SHA256_ARM64}\`"
+            echo
+            echo "### Files Updated"
+            for f in ${{ matrix.files }}; do echo "- \`$f\`"; done
+            echo
+            echo "Release: https://github.com/liquibase/liquibase-package-manager/releases/tag/v${VERSION}"
+            echo
+            echo "---"
+            echo
+            echo "*This PR was automatically created by the [LPM release automation](https://github.com/liquibase/liquibase-package-manager/actions/workflows/update-docker-repo.yml).*"
+          } > pr-body.md
+          {
+            echo "body<<EOF"
+            cat pr-body.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create Pull Request
-        if: steps.check-changes.outputs.changed == 'true'
+        if: steps.check.outputs.outcome == 'changed' && inputs.dry-run != true
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        id: create-pr
         with:
-          token: ${{ steps.get-token.outputs.token }}
-          commit-message: "Update LPM to version ${{ steps.version.outputs.version }}"
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: "Update LPM to version ${{ needs.prepare.outputs.version }}"
           committer: "liquibot <liquibot@liquibase.org>"
           author: "liquibot <liquibot@liquibase.org>"
-          branch: "update-lpm-${{ steps.version.outputs.version }}"
+          branch: "update-lpm-${{ needs.prepare.outputs.version }}"
           delete-branch: true
-          title: "Update LPM to v${{ steps.version.outputs.version }}"
-          body: |
-            ## Update LPM Version
-
-            This PR updates the Liquibase Package Manager (LPM) to version **${{ steps.version.outputs.version }}**.
-
-            ### Changes
-
-            - **LPM Version:** `${{ steps.version.outputs.version }}`
-            - **SHA256 (amd64):** `${{ steps.checksums.outputs.sha256_amd64 }}`
-            - **SHA256 (arm64):** `${{ steps.checksums.outputs.sha256_arm64 }}`
-
-            ### Files Updated
-
-            - [x] `Dockerfile`
-            - [x] `Dockerfile.alpine`
-            - [x] `DockerfileSecure`
-
-            ### Release Information
-
-            - **Release:** https://github.com/liquibase/liquibase-package-manager/releases/tag/v${{ steps.version.outputs.version }}
-            - **Automated by:** [Update Docker Repository workflow](https://github.com/liquibase/liquibase-package-manager/actions/workflows/update-docker-repo.yml)
-
-            ### Verification
-
-            The checksums have been automatically extracted from the official release and validated.
-
-            Please review and merge this PR to update the Docker images with the new LPM version.
-
-            ---
-
-            🤖 *This PR was automatically created by the LPM release automation.*
+          title: "Update LPM to v${{ needs.prepare.outputs.version }}"
+          body: ${{ steps.body.outputs.body }}
           labels: |
             lpm
             dependencies
             automated
           draft: false
 
-      - name: Summary
+      - name: Dry-run diff output
+        if: steps.check.outputs.outcome == 'changed' && inputs.dry-run == true
+        run: |
+          echo "DRY RUN: would create PR for ${{ matrix.repo }}"
+          echo "--- diff ---"
+          git diff
+
+      - name: Record outcome
+        id: record
         if: always()
         run: |
-          echo "## Update Docker Repository Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**LPM Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**SHA256 (amd64):** \`${{ steps.checksums.outputs.sha256_amd64 }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**SHA256 (arm64):** \`${{ steps.checksums.outputs.sha256_arm64 }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          if [ "${{ steps.check-changes.outputs.changed }}" = "true" ]; then
-            echo "✅ **Status:** PR created successfully" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Next Steps:**" >> $GITHUB_STEP_SUMMARY
-            echo "1. Review the PR in the [liquibase/docker repository](https://github.com/liquibase/docker/pulls)" >> $GITHUB_STEP_SUMMARY
-            echo "2. Verify the checksums match the release" >> $GITHUB_STEP_SUMMARY
-            echo "3. Merge the PR to trigger Docker image builds" >> $GITHUB_STEP_SUMMARY
+          REPO_SAFE=$(echo "${{ matrix.repo }}" | tr '/' '-')
+          if [ "${{ job.status }}" = "failure" ]; then
+            OUTCOME="failed"
+            PR_URL=""
+          elif [ "${{ steps.check.outputs.outcome }}" = "noop" ]; then
+            OUTCOME="noop"
+            PR_URL=""
+          elif [ "${{ inputs.dry-run }}" = "true" ]; then
+            OUTCOME="dry-run-would-create"
+            PR_URL=""
           else
-            echo "ℹ️ **Status:** No changes needed (version already up to date)" >> $GITHUB_STEP_SUMMARY
+            OUTCOME="created"
+            PR_URL="${{ steps.create-pr.outputs.pull-request-url }}"
           fi
+          echo "${{ matrix.repo }}|${OUTCOME}|${PR_URL}" > "outcome-${REPO_SAFE}.txt"
+          echo "Recorded outcome for ${{ matrix.repo }}: ${OUTCOME}"
+
+      - name: Upload outcome artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: outcome-${{ strategy.job-index }}
+          path: outcome-*.txt
+
+  # ─── Stage 3: Aggregate per-repo outcomes into one summary ───────────────────
+  # This job is INFORMATIONAL — its pass/fail does not override the matrix result.
+  # If any update-repo job failed, the overall run is already marked failed.
+  # needs: [prepare, update-repo] so that needs.prepare.outputs.version is accessible here.
+  summary:
+    name: Run summary
+    needs: [prepare, update-repo]
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+      - name: Download all outcome artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: outcome-*
+          merge-multiple: true
+
+      - name: Render step summary table
+        run: |
+          {
+            echo "## LPM Update Summary"
+            echo ""
+            echo "**LPM Version:** ${{ needs.prepare.outputs.version }}"
+            echo ""
+            echo "| Repo | Outcome | PR |"
+            echo "|------|---------|-----|"
+
+            for f in outcome-*.txt; do
+              [ -f "$f" ] || continue
+              IFS='|' read -r repo outcome pr_url < "$f"
+              if [ -n "$pr_url" ]; then
+                PR_CELL="[PR]($pr_url)"
+              else
+                PR_CELL="—"
+              fi
+              echo "| \`${repo}\` | ${outcome} | ${PR_CELL} |"
+            done
+
+            echo ""
+            echo "> **Note:** If any repo job failed, the overall run is marked \`failed\`. This is intentional alerting — check the per-repo rows above for details."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/update-docker-repo.yml
+++ b/.github/workflows/update-docker-repo.yml
@@ -25,6 +25,12 @@ on:
         type: boolean
         default: false
 
+# Serialize runs so two releases in quick succession cannot race on the shared
+# "latest release" resolution or open conflicting PRs; queue instead of cancelling.
+concurrency:
+  group: update-docker-repo
+  cancel-in-progress: false
+
 # Permissions are scoped per job (least privilege) — only update-repo needs id-token: write for AWS OIDC.
 jobs:
   # ─── Stage 1: Compute version + checksums ONCE ───────────────────────────────
@@ -33,6 +39,7 @@ jobs:
   prepare:
     name: Prepare version and checksums
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read  # read public release data via GITHUB_TOKEN
@@ -45,21 +52,35 @@ jobs:
       - name: Extract version from release
         id: version
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            # Get the latest published release tag for this repo
+            # On workflow_run, resolve the most recently PUBLISHED release. At our
+            # release cadence that is the release that just triggered the upstream
+            # "Build and Attach Artifacts" run, and the workflow-level concurrency
+            # group serializes runs so two releases cannot race here. Draft releases
+            # have a null published_at, which jq sorts last after reverse, so they
+            # are never selected.
             TAG_NAME=$(gh api \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               /repos/${{ github.repository }}/releases \
               --jq 'sort_by(.published_at) | reverse | .[0].tag_name')
             VERSION="${TAG_NAME#v}"
-            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "Using version from latest release: $VERSION"
           else
             VERSION="$LPM_VERSION_INPUT"
-            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "Using manual input version: $VERSION"
           fi
+
+          # Validate the version format before it flows into a URL, sed, and a
+          # branch name. Mirrors the strict SHA gate below and also fails fast on an
+          # empty/unresolved version (e.g. a transient gh-api failure) at its root.
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid or unresolved LPM version: '$VERSION' (expected N.N.N)"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LPM_VERSION_INPUT: ${{ inputs.lpm-version }}
@@ -69,6 +90,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
 
           # Download checksums.txt from release
@@ -102,14 +124,18 @@ jobs:
           INPUT_SHA256_AMD64: ${{ inputs.sha256-amd64 }}
           INPUT_SHA256_ARM64: ${{ inputs.sha256-arm64 }}
         run: |
+          set -euo pipefail
           # Use dispatch overrides when BOTH are supplied; otherwise parse from checksums.txt
           if [ -n "$INPUT_SHA256_AMD64" ] && [ -n "$INPUT_SHA256_ARM64" ]; then
             SHA256_AMD64="$INPUT_SHA256_AMD64"
             SHA256_ARM64="$INPUT_SHA256_ARM64"
             echo "Using manually supplied SHA256 overrides"
           else
-            SHA256_AMD64=$(grep "lpm-${VERSION}-linux.zip" checksums.txt | awk '{print $1}')
-            SHA256_ARM64=$(grep "lpm-${VERSION}-linux-arm64.zip" checksums.txt | awk '{print $1}')
+            # -F: match the asset name literally so the dots are not regex wildcards.
+            # || true: a no-match is handled by the 64-hex validation gate below,
+            # not by aborting under pipefail with a confusing error.
+            SHA256_AMD64=$(grep -F "lpm-${VERSION}-linux.zip" checksums.txt | awk '{print $1}' || true)
+            SHA256_ARM64=$(grep -F "lpm-${VERSION}-linux-arm64.zip" checksums.txt | awk '{print $1}' || true)
 
             # Fall back to individual override if only one was supplied
             if [ -n "$INPUT_SHA256_AMD64" ]; then
@@ -141,6 +167,7 @@ jobs:
     name: "Update ${{ matrix.repo }}"
     needs: prepare
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: ${{ needs.prepare.result == 'success' }}
     permissions:
       contents: read   # checkout target repos uses the App token, not GITHUB_TOKEN
@@ -288,9 +315,13 @@ jobs:
           elif [ "$DRY_RUN" = "true" ]; then
             OUTCOME="dry-run-would-create"
             PR_URL=""
-          else
+          elif [ -n "${{ steps.create-pr.outputs.pull-request-url }}" ]; then
             OUTCOME="created"
             PR_URL="${{ steps.create-pr.outputs.pull-request-url }}"
+          else
+            # PR step ran but produced no URL (rare) — report honestly, don't claim "created".
+            OUTCOME="no-pr"
+            PR_URL=""
           fi
           echo "${{ matrix.repo }}|${OUTCOME}|${PR_URL}" > "outcome-${REPO_SAFE}.txt"
           echo "Recorded outcome for ${{ matrix.repo }}: ${OUTCOME}"
@@ -310,6 +341,7 @@ jobs:
     name: Run summary
     needs: [prepare, update-repo]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: always() && needs.prepare.result != 'skipped'
     permissions:
       contents: read

--- a/.github/workflows/update-docker-repo.yml
+++ b/.github/workflows/update-docker-repo.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Download checksums file
         id: download-checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
@@ -76,7 +78,7 @@ jobs:
             echo "Direct download failed. Trying release assets API..."
 
             # Fallback: resolve the asset URL via the GitHub releases API
-            curl -sfL --proto '=https' --proto-redir '=https' -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            curl -sfL --proto '=https' --proto-redir '=https' -H "Authorization: token $GH_TOKEN" \
               "https://api.github.com/repos/liquibase/liquibase-package-manager/releases/tags/v${VERSION}" \
               > release.json
 

--- a/.github/workflows/update-docker-repo.yml
+++ b/.github/workflows/update-docker-repo.yml
@@ -144,8 +144,8 @@ jobs:
         include:
           - repo: liquibase/liquibase
             files: "docker/Dockerfile docker/Dockerfile.alpine"
-          - repo: liquibase/liquibase-pro  # PRIVATE — needs App install (P2) + live-file confirm (P1)
-            files: "core/docker/Dockerfile core/docker/Dockerfile.alpine docker/Dockerfile"
+          - repo: liquibase/liquibase-pro  # PRIVATE — needs App install (P2). core/docker/* is legacy and must NOT be updated; only docker/Dockerfile is live.
+            files: "docker/Dockerfile"
 
     steps:
       # Token re-minted here per-job — never passed via job output (see TECHOPS-603 design Decision 1)

--- a/.github/workflows/update-docker-repo.yml
+++ b/.github/workflows/update-docker-repo.yml
@@ -25,10 +25,7 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: read
-  id-token: write  # Required for AWS OIDC in every job
-
+# Permissions are scoped per job (least privilege) — only update-repo needs id-token: write for AWS OIDC.
 jobs:
   # ─── Stage 1: Compute version + checksums ONCE ───────────────────────────────
   # This job uses only GITHUB_TOKEN (read-only) to read public release data.
@@ -37,6 +34,8 @@ jobs:
     name: Prepare version and checksums
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read  # read public release data via GITHUB_TOKEN
     outputs:
       version:      ${{ steps.version.outputs.version }}
       sha256_amd64: ${{ steps.checksums.outputs.sha256_amd64 }}
@@ -57,12 +56,13 @@ jobs:
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "Using version from latest release: $VERSION"
           else
-            VERSION="${{ inputs.lpm-version }}"
+            VERSION="$LPM_VERSION_INPUT"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "Using manual input version: $VERSION"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LPM_VERSION_INPUT: ${{ inputs.lpm-version }}
 
       - name: Download checksums file
         id: download-checksums
@@ -95,24 +95,26 @@ jobs:
 
       - name: Extract and validate SHA256 checksums
         id: checksums
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          INPUT_SHA256_AMD64: ${{ inputs.sha256-amd64 }}
+          INPUT_SHA256_ARM64: ${{ inputs.sha256-arm64 }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
           # Use dispatch overrides when BOTH are supplied; otherwise parse from checksums.txt
-          if [ -n "${{ inputs.sha256-amd64 }}" ] && [ -n "${{ inputs.sha256-arm64 }}" ]; then
-            SHA256_AMD64="${{ inputs.sha256-amd64 }}"
-            SHA256_ARM64="${{ inputs.sha256-arm64 }}"
+          if [ -n "$INPUT_SHA256_AMD64" ] && [ -n "$INPUT_SHA256_ARM64" ]; then
+            SHA256_AMD64="$INPUT_SHA256_AMD64"
+            SHA256_ARM64="$INPUT_SHA256_ARM64"
             echo "Using manually supplied SHA256 overrides"
           else
             SHA256_AMD64=$(grep "lpm-${VERSION}-linux.zip" checksums.txt | awk '{print $1}')
             SHA256_ARM64=$(grep "lpm-${VERSION}-linux-arm64.zip" checksums.txt | awk '{print $1}')
 
             # Fall back to individual override if only one was supplied
-            if [ -n "${{ inputs.sha256-amd64 }}" ]; then
-              SHA256_AMD64="${{ inputs.sha256-amd64 }}"
+            if [ -n "$INPUT_SHA256_AMD64" ]; then
+              SHA256_AMD64="$INPUT_SHA256_AMD64"
             fi
-            if [ -n "${{ inputs.sha256-arm64 }}" ]; then
-              SHA256_ARM64="${{ inputs.sha256-arm64 }}"
+            if [ -n "$INPUT_SHA256_ARM64" ]; then
+              SHA256_ARM64="$INPUT_SHA256_ARM64"
             fi
           fi
 
@@ -138,6 +140,9 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     if: ${{ needs.prepare.result == 'success' }}
+    permissions:
+      contents: read   # checkout target repos uses the App token, not GITHUB_TOKEN
+      id-token: write  # AWS OIDC → Vault → GitHub App token mint
     strategy:
       fail-fast: false  # One repo failing must not cancel others (R6)
       matrix:
@@ -192,9 +197,9 @@ jobs:
             fi
             # NOTE: ^ARG LPM_SHA256= matches amd64 ONLY — the trailing = cannot match
             # LPM_SHA256_ARM= (which has _ARM before the =). The = boundary is load-bearing.
-            sed -i "s/^ARG LPM_VERSION=.*/ARG LPM_VERSION=${VERSION}/"            "$f"
-            sed -i "s/^ARG LPM_SHA256=.*/ARG LPM_SHA256=${SHA256_AMD64}/"         "$f"
-            sed -i "s/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM=${SHA256_ARM64}/" "$f"
+            sed -i "s|^ARG LPM_VERSION=.*|ARG LPM_VERSION=${VERSION}|"            "$f"
+            sed -i "s|^ARG LPM_SHA256=.*|ARG LPM_SHA256=${SHA256_AMD64}|"         "$f"
+            sed -i "s|^ARG LPM_SHA256_ARM=.*|ARG LPM_SHA256_ARM=${SHA256_ARM64}|" "$f"
             echo "Updated $f:"
             grep -E "^ARG LPM_(VERSION|SHA256|SHA256_ARM)=" "$f"
           done
@@ -268,6 +273,8 @@ jobs:
       - name: Record outcome
         id: record
         if: always()
+        env:
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
           REPO_SAFE=$(echo "${{ matrix.repo }}" | tr '/' '-')
           if [ "${{ job.status }}" = "failure" ]; then
@@ -276,7 +283,7 @@ jobs:
           elif [ "${{ steps.check.outputs.outcome }}" = "noop" ]; then
             OUTCOME="noop"
             PR_URL=""
-          elif [ "${{ inputs.dry-run }}" = "true" ]; then
+          elif [ "$DRY_RUN" = "true" ]; then
             OUTCOME="dry-run-would-create"
             PR_URL=""
           else
@@ -302,6 +309,8 @@ jobs:
     needs: [prepare, update-repo]
     runs-on: ubuntu-latest
     if: always() && needs.prepare.result != 'skipped'
+    permissions:
+      contents: read
 
     steps:
       - name: Download all outcome artifacts

--- a/.github/workflows/update-docker-repo.yml
+++ b/.github/workflows/update-docker-repo.yml
@@ -204,6 +204,7 @@ jobs:
           app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ matrix.repo }}  # scope the token to just this target repo (least privilege)
 
       - name: Checkout ${{ matrix.repo }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -211,6 +212,7 @@ jobs:
           repository: ${{ matrix.repo }}
           ref: main
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false  # peter-evans uses the token input directly; don't leave it in git config
 
       - name: Update LPM ARGs in Dockerfiles
         env:

--- a/.github/workflows/update-docker-repo.yml
+++ b/.github/workflows/update-docker-repo.yml
@@ -71,19 +71,19 @@ jobs:
 
           # Download checksums.txt from release
           echo "Downloading checksums for version $VERSION..."
-          if ! curl -sfL -o checksums.txt \
+          if ! curl -sfL --proto '=https' --proto-redir '=https' -o checksums.txt \
             "https://github.com/liquibase/liquibase-package-manager/releases/download/v${VERSION}/checksums.txt"; then
             echo "Direct download failed. Trying release assets API..."
 
             # Fallback: resolve the asset URL via the GitHub releases API
-            curl -sfL -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            curl -sfL --proto '=https' --proto-redir '=https' -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               "https://api.github.com/repos/liquibase/liquibase-package-manager/releases/tags/v${VERSION}" \
               > release.json
 
             CHECKSUMS_URL=$(jq -r '.assets[] | select(.name == "checksums.txt") | .browser_download_url' release.json)
 
             if [ -n "$CHECKSUMS_URL" ] && [ "$CHECKSUMS_URL" != "null" ]; then
-              curl -sfL -o checksums.txt "$CHECKSUMS_URL"
+              curl -sfL --proto '=https' --proto-redir '=https' -o checksums.txt "$CHECKSUMS_URL"
             else
               echo "::error::checksums.txt not found in release assets for v${VERSION}"
               exit 1

--- a/.github/workflows/update-docker-repo.yml
+++ b/.github/workflows/update-docker-repo.yml
@@ -290,7 +290,7 @@ jobs:
 
       - name: Upload outcome artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: outcome-${{ strategy.job-index }}
           path: outcome-*.txt
@@ -303,11 +303,11 @@ jobs:
     name: Run summary
     needs: [prepare, update-repo]
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && needs.prepare.result != 'skipped'
 
     steps:
       - name: Download all outcome artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: outcome-*
           merge-multiple: true

--- a/.github/workflows/update-docker-repo.yml
+++ b/.github/workflows/update-docker-repo.yml
@@ -146,8 +146,6 @@ jobs:
             files: "docker/Dockerfile docker/Dockerfile.alpine"
           - repo: liquibase/liquibase-pro  # PRIVATE — needs App install (P2) + live-file confirm (P1)
             files: "core/docker/Dockerfile core/docker/Dockerfile.alpine docker/Dockerfile"
-          - repo: liquibase/docker  # TODO: remove after TECHOPS-366 archives this repo
-            files: "Dockerfile Dockerfile.alpine DockerfileSecure"
 
     steps:
       # Token re-minted here per-job — never passed via job output (see TECHOPS-603 design Decision 1)


### PR DESCRIPTION
## The problem

Every LPM release ships fresh checksums — but the release automation only patched **`liquibase/docker`**, the repo being archived under TECHOPS-366. The live consumers (`liquibase/liquibase`, `liquibase/liquibase-pro`) never got the bump, so they drifted (0.3.4 while `docker` sat at 0.3.3) and had to be hand-edited. That hand-edit is exactly the failure mode that broke the Secure 5.0.2 image in **DAT-21257** (LPM version and SHA out of sync).

## What this does

Rewrites `update-docker-repo.yml` from a single hardcoded job into a **two-stage matrix fanout**:

- **`prepare`** (runs once): extracts the version and downloads + validates `checksums.txt` — both SHA256 values, 64-char checked. Exposes version + both SHAs as outputs.
- **`update-repo`** (`needs: prepare`, `strategy.matrix`, `fail-fast: false`): one isolated job per consumer repo. Each job re-mints the GitHub App token, checks out the target repo, updates every `ARG LPM_VERSION` / `LPM_SHA256` / `LPM_SHA256_ARM` across that repo's files, and opens a focused PR. No-op (already current) opens no PR.
- **`summary`**: aggregates per-repo outcomes (created / no-op / failed) into one Step Summary table.

The deprecated **`liquibase/docker`** repo is dropped entirely — it is no longer an LPM consumer.

## The result

One LPM release → a PR in **every** in-scope consumer, with identical checksums computed once. Version and SHAs can no longer drift apart across repos — the DAT-21257 class is structurally dead. Adding a future consumer is a **one-line matrix entry**.

---

Implements **[TECHOPS-603](https://datical.atlassian.net/browse/TECHOPS-603)**.

### Why these design calls (the load-bearing three)

- **Token never crosses a job boundary.** The GitHub App write-token is re-minted *inside* each matrix job (AWS OIDC → Vault → `create-github-app-token`), never passed via job outputs — job outputs aren't secrets and masking is fragile. Biggest leak path, closed.
- **Checksums computed once, distributed identically.** `prepare` validates both SHAs a single time; every repo consumes the same values. No per-repo recompute, no drift.
- **Failure aggregation via artifacts, not matrix outputs.** GitHub Actions silently drops/overwrites matrix-job `outputs`; each job uploads a small outcome artifact the `summary` job collects instead.

### Changes

| File | Change |
|------|--------|
| `.github/workflows/update-docker-repo.yml` | Single-repo job → `prepare` + per-repo matrix fanout + `summary`; per-job token re-mint; per-file update loop with fail-on-missing; `dry-run` input; artifact-based outcome aggregation; existing `workflow_dispatch` inputs preserved; `liquibase/docker` removed |
| `.github/workflows/README-docker-update.md` | Documents the matrix config, how to add/remove a consumer, the `dry-run` input, the out-of-scope repos, and the partial-failure semantics |

### In-scope target matrix

- `liquibase/liquibase` — `docker/Dockerfile`, `docker/Dockerfile.alpine`
- `liquibase/liquibase-pro` — `docker/Dockerfile` *(the live Secure image; `core/docker/*` is legacy and intentionally **not** updated)*

`liquibase/docker` is **no longer a consumer** and has been removed from the automation.

Out of scope (documented in the README): `liquibase-test-harness`, `mongodemo`, `flow-demo`, `devops-misc` — they pin old LPM intentionally.

### Validation

- [x] `actionlint` clean on the rewritten workflow
- [x] Adversarial fresh-context review (spec/design conformance) — pass, 0 critical
- [ ] **T11 (human gate):** live `workflow_dispatch` dry-run against v0.3.5 — the `dry-run` input updates files + prints the diff without opening PRs
- _No Go unit tests apply — this is a CI workflow change; the gate is actionlint + dry-run, not `go test`._

### ⚠️ Human gate before merge

- [ ] **P2 (blocker):** Confirm the Liquibase GitHub App is installed on `liquibase/liquibase` **and** private `liquibase/liquibase-pro` with `contents:write` + `pull-requests:write`. Without it, the pro matrix job 403s. Org-settings check, not code.


[TECHOPS-603]: https://datical.atlassian.net/browse/TECHOPS-603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ