### PR TITLE
[TECHOPS-911] Add liquibase-aws-license-service v1.0.7 to package catalog

### DIFF
--- a/internal/app/packages.json
+++ b/internal/app/packages.json
@@ -71,6 +71,13 @@
         "algorithm": "SHA1",
         "checksum": "7f156c9086a4ee01f67e4c7ac84fee32187dc53b",
         "liquibaseCore": "5.0.3"
+      },
+      {
+        "tag": "v1.0.7",
+        "path": "https://github.com/liquibase/liquibase-aws-license-service/releases/download/v1.0.7/liquibase-aws-license-service-1.0.7.jar",
+        "algorithm": "SHA1",
+        "checksum": "42d17478d9e14191f5812952dcf4a5a08343bc12",
+        "liquibaseCore": "5.0.3"
       }
     ]
   },


### PR DESCRIPTION
## 🔗 Jira
[TECHOPS-911](https://datical.atlassian.net/browse/TECHOPS-911)

## What
Adds **liquibase-aws-license-service v1.0.7** to the LPM catalog (`internal/app/packages.json`) so it is installable via `lpm`.

```json
{
  "tag": "v1.0.7",
  "path": ".../v1.0.7/liquibase-aws-license-service-1.0.7.jar",
  "algorithm": "SHA1",
  "checksum": "42d17478d9e14191f5812952dcf4a5a08343bc12",
  "liquibaseCore": "5.0.3"
}
```
The checksum was verified against the actual release jar bytes (`shasum -a 1` matches the release `.jar.sha1`), and the path points at the real 13 MB distribution jar.

## Why manual (the automated run did not produce this)
The `Update Packages` workflow ran ([run 29429950143](https://github.com/liquibase/liquibase-package-manager/actions/runs/29429950143) and a re-run) and reported success, but **no PR was opened**. Root cause:

- The populator (`cmd/populator`) fetches each extension's POM via `GetPomFromURL`, which does not check the HTTP status and feeds the body straight to `xml.Unmarshal`.
- **Maven Central rate-limited the run with HTTP 429**; the 429 body (empty in CI → `EOF`; a short anti-abuse page locally) fails `xml.Unmarshal`, and `GetPomFromURL` calls `log.Fatal`, aborting the whole populator **before `packages.json` is written** — so v1.0.7 (valid, unrelated to the failing module) was never added.
- The workflow's guard only fails the build on exit code `404`, so a generic crash exits `0` and the step looks green (`peter-evans/create-pull-request` then has nothing to commit). That is why there was no PR and no alert.

Because it is a rate-limit/robustness issue, this entry was generated + hand-verified rather than waiting on the automated job.

## Note on the populator's jar selection
When run, the populator picks the **wrong** jar for v1.0.7 (`..._proguard_base.jar`, an 8 KB stub) because its "last `.jar` asset wins" logic is confused by the extra javadoc/sources/proguard jars in this release. This PR intentionally points at the correct main jar.

## Recommended follow-up (separate PR, TECHOPS-911)
Harden the populator so this cannot silently recur:
1. `GetPomFromURL`: check HTTP status, retry with backoff on 429/5xx, and return `nil` instead of `log.Fatal` so one bad artifact does not abort the run.
2. Prefer the exact `<artifact>-<version>.jar` asset instead of "last `.jar` wins".
3. Fix the `Update Packages` workflow guard to fail on any non-zero exit, not only `404`, so failures are loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TECHOPS-911]: https://datical.atlassian.net/browse/TECHOPS-911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ